### PR TITLE
chore: minor changes

### DIFF
--- a/cmd/bundle/verify/verify_test.go
+++ b/cmd/bundle/verify/verify_test.go
@@ -1,7 +1,6 @@
 package verify
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -57,7 +56,7 @@ func TestRunOfflineMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{}
-			cmd.SetContext(context.Background())
+			cmd.SetContext(t.Context())
 
 			err := run(cmd, tt.args, tt.opts)
 
@@ -112,7 +111,7 @@ func TestRunWithCacheDir(t *testing.T) {
 			cacheDir := testutil.CreateCacheDir(t, cacheConfigData)
 
 			cmd := &cobra.Command{}
-			cmd.SetContext(context.Background())
+			cmd.SetContext(t.Context())
 
 			args := []string{cacheDir + "/" + testutil.BundleFile}
 			err = run(cmd, args, tt.opts)

--- a/internal/bundle/generator.go
+++ b/internal/bundle/generator.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"context"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/x509"
@@ -199,7 +200,7 @@ func (g *Generator) GenerateWithMetadata(cfg *config.TPMRootsConfig, workers int
 
 // processCertificate downloads, validates, and converts a certificate to PEM with a comment header.
 func (g *Generator) processCertificate(cert config.Certificate, vendorID string) (string, error) {
-	x509Cert, err := g.downloader.DownloadCertificate(cert.URL)
+	x509Cert, err := g.downloader.DownloadCertificate(context.Background(), cert.URL)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/download/download.go
+++ b/internal/config/download/download.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -15,14 +16,13 @@ type Client struct {
 	HTTPClient utils.HttpClient
 }
 
+var defaultClient = &http.Client{
+	Timeout: 5 * time.Second,
+}
+
 // NewClient creates a new download client with sensible defaults.
 func NewClient(optionalClient ...utils.HttpClient) *Client {
-	client, err := utils.OptionalArg(optionalClient)
-	if err != nil {
-		client = &http.Client{
-			Timeout: 5 * time.Second,
-		}
-	}
+	client := utils.OptionalArgWithDefault[utils.HttpClient](optionalClient, defaultClient)
 	return &Client{
 		HTTPClient: client,
 	}
@@ -36,12 +36,12 @@ func NewClient(optionalClient ...utils.HttpClient) *Client {
 // Example:
 //
 //	client := download.NewClient()
-//	certBytes, err := client.DownloadCertificate("https://example.com/cert.cer")
+//	certBytes, err := client.DownloadCertificate(ctx, "https://example.com/cert.cer")
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-func (c *Client) DownloadCertificate(url string) (*x509.Certificate, error) {
-	data, err := utils.HttpGET(c.HTTPClient, url)
+func (c *Client) DownloadCertificate(ctx context.Context, url string) (*x509.Certificate, error) {
+	data, err := utils.HttpGET(ctx, c.HTTPClient, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download certificate from %s: %w", url, err)
 	}

--- a/internal/config/download/download_test.go
+++ b/internal/config/download/download_test.go
@@ -21,7 +21,7 @@ func TestDownloadCertificate(t *testing.T) {
 		defer server.Close()
 
 		client := download.NewClient(server.Client())
-		_, err := client.DownloadCertificate(server.URL)
+		_, err := client.DownloadCertificate(t.Context(), server.URL)
 		if err != nil {
 			t.Fatalf("DownloadCertificate() error = %v", err)
 		}
@@ -34,7 +34,7 @@ func TestDownloadCertificate(t *testing.T) {
 		defer server.Close()
 
 		client := download.NewClient(server.Client())
-		_, err := client.DownloadCertificate(server.URL)
+		_, err := client.DownloadCertificate(t.Context(), server.URL)
 		if err == nil {
 			t.Error("DownloadCertificate() expected error for 404")
 		}
@@ -54,7 +54,7 @@ func TestDownloadCertificate(t *testing.T) {
 		defer server.Close()
 
 		client := download.NewClient(server.Client())
-		_, err := client.DownloadCertificate(server.URL)
+		_, err := client.DownloadCertificate(t.Context(), server.URL)
 		if err == nil {
 			t.Error("DownloadCertificate() expected error for empty response")
 		}
@@ -65,7 +65,7 @@ func TestDownloadCertificate(t *testing.T) {
 
 	t.Run("invalid url", func(t *testing.T) {
 		client := download.NewClient()
-		_, err := client.DownloadCertificate("://invalid-url")
+		_, err := client.DownloadCertificate(t.Context(), "://invalid-url")
 		if err == nil {
 			t.Error("DownloadCertificate() expected error for invalid URL")
 		}

--- a/internal/config/sanity/sanity.go
+++ b/internal/config/sanity/sanity.go
@@ -1,6 +1,7 @@
 package sanity
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -163,7 +164,7 @@ func (c *Checker) Check(cfg *config.TPMRootsConfig, workers int, thresholdDays i
 
 // checkCertificate validates a single certificate and checks its expiration.
 func (c *Checker) checkCertificate(cert config.Certificate, vendorID, vendorName string, thresholdDays int) (*ValidationError, *ExpirationWarning, error) {
-	x509Cert, err := c.downloader.DownloadCertificate(cert.URL)
+	x509Cert, err := c.downloader.DownloadCertificate(context.Background(), cert.URL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to download certificate %q from vendor %q: %w", cert.Name, vendorName, err)
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -37,10 +37,7 @@ type HTTPClient struct {
 // The client uses the provided http.Client for making requests.
 // If nil is provided, http.DefaultClient is used.
 func NewHTTPClient(optionalClient ...utils.HttpClient) *HTTPClient {
-	client, err := utils.OptionalArg(optionalClient)
-	if err != nil {
-		client = http.DefaultClient
-	}
+	client := utils.OptionalArgWithDefault[utils.HttpClient](optionalClient, http.DefaultClient)
 	return &HTTPClient{
 		client: client,
 		token:  os.Getenv("GITHUB_TOKEN"),
@@ -118,7 +115,7 @@ func (c *HTTPClient) GetAttestations(ctx context.Context, repo Repo, digest stri
 // GitHub stores bundles as snappy-compressed protobuf JSON at bundle_url.
 // However, for inline bundles in the API response, no decompression is needed.
 func (c *HTTPClient) fetchBundle(ctx context.Context, bundleURL string) (*bundle.Bundle, error) {
-	bundleBytes, err := utils.HttpGET(c.client, bundleURL)
+	bundleBytes, err := utils.HttpGET(ctx, c.client, bundleURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch bundle: %w", err)
 	}
@@ -322,7 +319,7 @@ func (c *HTTPClient) DownloadReleaseAsset(ctx context.Context, repo Repo, tag, a
 		return nil, fmt.Errorf("asset %q not found in release %q", assetName, tag)
 	}
 
-	data, err := utils.HttpGET(c.client, assetURL)
+	data, err := utils.HttpGET(ctx, c.client, assetURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download file: %w", err)
 	}

--- a/internal/transparency/utils/verifier/verifier.go
+++ b/internal/transparency/utils/verifier/verifier.go
@@ -53,11 +53,7 @@ func New(cfg Config) (*verify.Verifier, error) {
 
 // GetDefaultTUFOptions returns TUF options with sane defaults for Sigstore usage.
 func GetDefaultTUFOptions(optionalClient ...utils.HttpClient) *tuf.Options {
-	client, err := utils.OptionalArg(optionalClient)
-	if err != nil {
-		client = nil
-	}
-
+	client := utils.OptionalArg(optionalClient)
 	opts := tuf.DefaultOptions()
 
 	// Store TUF cache in a directory owned by tpmtb for better isolation
@@ -90,11 +86,7 @@ func GetDefaultTUFOptions(optionalClient ...utils.HttpClient) *tuf.Options {
 //	}
 //	os.WriteFile("trusted-root.json", trustedRootJSON, 0644)
 func FetchTrustedRoot(optionalClient ...utils.HttpClient) ([]byte, error) {
-	client, err := utils.OptionalArg(optionalClient)
-	if err != nil {
-		client = nil
-	}
-
+	client := utils.OptionalArg(optionalClient)
 	opts := GetDefaultTUFOptions(client)
 	opts.DisableLocalCache = true
 
@@ -108,5 +100,10 @@ func FetchTrustedRoot(optionalClient ...utils.HttpClient) ([]byte, error) {
 		return nil, fmt.Errorf("failed to retrieve trusted_root.json via TUF: %w", err)
 	}
 
-	return target, nil
+	output, err := utils.JsonCompact(target)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
 }

--- a/internal/utils/args.go
+++ b/internal/utils/args.go
@@ -4,7 +4,7 @@ import "errors"
 
 var ErrArgNotProvided = errors.New("argument not provided")
 
-func OptionalArg[T any](arg []T) (T, error) {
+func optionalArg[T any](arg []T) (T, error) {
 	if len(arg) == 0 {
 		var zero T
 		return zero, ErrArgNotProvided
@@ -12,8 +12,17 @@ func OptionalArg[T any](arg []T) (T, error) {
 	return arg[0], nil
 }
 
+// OptionalArg returns the first element of the provided slice,
+// or the zero value of T if the slice is empty.
+func OptionalArg[T any](arg []T) T {
+	v, _ := optionalArg(arg)
+	return v
+}
+
+// OptionalArgWithDefault returns the first element of the provided slice,
+// or the provided defaultValue if the slice is empty.
 func OptionalArgWithDefault[T any](arg []T, defaultValue T) T {
-	v, err := OptionalArg(arg)
+	v, err := optionalArg(arg)
 	if err != nil {
 		return defaultValue
 	}

--- a/internal/utils/args_test.go
+++ b/internal/utils/args_test.go
@@ -1,0 +1,79 @@
+package utils_test
+
+import (
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/loicsikidi/tpm-ca-certificates/internal/utils"
+)
+
+type TestCase[T any] struct {
+	name string
+	args []T
+	want T
+}
+
+func TestOptionalArg(t *testing.T) {
+	tint := []TestCase[int]{
+		{
+			name: "argument provided",
+			args: []int{42},
+			want: 42,
+		},
+		{
+			name: "argument not provided",
+			args: []int{},
+			want: 0,
+		},
+	}
+	tinterface := []TestCase[utils.HttpClient]{
+		{
+			name: "argument provided",
+			args: []utils.HttpClient{http.DefaultClient},
+			want: http.DefaultClient,
+		},
+		{
+			name: "argument not provided",
+			args: []utils.HttpClient{},
+			want: nil,
+		},
+	}
+	tslice := []TestCase[[]int]{
+		{
+			name: "argument provided",
+			args: [][]int{{1, 2, 3}, {4, 5, 6}},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "argument not provided",
+			args: [][]int{},
+			want: nil,
+		},
+	}
+
+	testOptionalArg(t, tint)
+	testOptionalArg(t, tinterface)
+	testOptionalArgWithSlice(t, tslice)
+}
+
+func testOptionalArg[T comparable](t *testing.T, tests []TestCase[T]) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := utils.OptionalArg(tt.args)
+			if got != tt.want {
+				t.Errorf("OptionalArg() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func testOptionalArgWithSlice[S ~[]E, E comparable](t *testing.T, tests []TestCase[S]) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := utils.OptionalArg(tt.args)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("OptionalArg() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -36,11 +36,7 @@ func DirExists(path string) bool {
 // If filename is "-", reads from stdin.
 // Default maximum size is [DefaultMaxFileSize], but can be overridden by providing a custom maxSize in bytes.
 func ReadFile(filename string, optionalMaxSize ...int64) ([]byte, error) {
-	maxSize, err := OptionalArg(optionalMaxSize)
-	if err != nil {
-		maxSize = DefaultMaxFileSize
-	}
-
+	maxSize := OptionalArgWithDefault(optionalMaxSize, DefaultMaxFileSize)
 	var reader io.Reader
 	if filename == "-" {
 		reader = os.Stdin

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,10 +1,16 @@
 package utils
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
 )
 
 var (
@@ -12,57 +18,120 @@ var (
 	ErrHTTPGetError    = fmt.Errorf("error during HTTP GET request")
 )
 
+const (
+	maxRetries = 4 // Total attempts: 1 initial + 3 retries
+)
+
+// DefaultBackoffConfig holds the default exponential backoff configuration for HTTP retries.
+// Can be modified for testing purposes.
+var DefaultBackoffConfig = &backoff.ExponentialBackOff{
+	InitialInterval:     100 * time.Millisecond,
+	MaxInterval:         500 * time.Millisecond,
+	Multiplier:          2.0, // Double the interval each retry
+	RandomizationFactor: 0.5, // Default randomization factor (±50%)
+}
+
 type HttpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func HttpGET(client HttpClient, url string, otionalMaxLength ...int64) ([]byte, error) {
-	maxLength, err := OptionalArg(otionalMaxLength)
-	if err != nil {
-		maxLength = DefaultMaxFileSize
+func HttpGET(ctx context.Context, client HttpClient, url string, optionalMaxLength ...int64) ([]byte, error) {
+	maxLength := OptionalArgWithDefault(optionalMaxLength, DefaultMaxFileSize)
+	c := client
+	if c == nil {
+		c = http.DefaultClient
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		err := fmt.Errorf("failed to download from %s: HTTP %d", url, res.StatusCode)
-		return nil, fmt.Errorf("%w: %v", ErrHTTPGetError, err)
+	expBackoff := &backoff.ExponentialBackOff{
+		InitialInterval:     DefaultBackoffConfig.InitialInterval,
+		MaxInterval:         DefaultBackoffConfig.MaxInterval,
+		Multiplier:          DefaultBackoffConfig.Multiplier,
+		RandomizationFactor: DefaultBackoffConfig.RandomizationFactor,
 	}
 
-	var length int64
-	if header := res.Header.Get("Content-Length"); header != "" {
-		length, err = strconv.ParseInt(header, 10, 0)
+	operation := func() ([]byte, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+
+		res, err := c.Do(req)
+		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+
+		if res.StatusCode >= 500 && res.StatusCode < 600 {
+			res.Body.Close()
+			return nil, fmt.Errorf("failed to download from %s: HTTP %d", url, res.StatusCode)
+		}
+
+		if res.StatusCode != http.StatusOK {
+			res.Body.Close()
+			err := fmt.Errorf("failed to download from %s: HTTP %d", url, res.StatusCode)
+			return nil, backoff.Permanent(fmt.Errorf("%w: %v", ErrHTTPGetError, err))
+		}
+
+		// Process successful response
+		var length int64
+		if header := res.Header.Get("Content-Length"); header != "" {
+			length, err = strconv.ParseInt(header, 10, 0)
+			if err != nil {
+				res.Body.Close()
+				return nil, backoff.Permanent(err)
+			}
+			if length > maxLength {
+				res.Body.Close()
+				err := fmt.Errorf("download failed for %s, length %d is larger than expected %d", url, length, maxLength)
+				return nil, backoff.Permanent(fmt.Errorf("%w: %v", ErrHTTPGetTooLarge, err))
+			}
+		}
+
+		// Although the size has been checked above, use a LimitReader in case
+		// the reported size is inaccurate.
+		data, err := io.ReadAll(io.LimitReader(res.Body, maxLength+1))
+		res.Body.Close()
+		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+
+		length = int64(len(data))
+		if int64(length) > maxLength {
+			err := fmt.Errorf("download failed for %s, length %d is larger than expected %d", url, length, maxLength)
+			return nil, backoff.Permanent(fmt.Errorf("%w: %v", ErrHTTPGetTooLarge, err))
+		}
+		return data, nil
+	}
+
+	data, err := backoff.Retry(ctx, operation, backoff.WithBackOff(expBackoff), backoff.WithMaxTries(maxRetries))
+	if err != nil {
+		// backoff.Retry automatically unwraps permanent errors
+		// So errors here are either:
+		// 1. Already unwrapped permanent errors (client errors, ErrHTTPGetError, ErrHTTPGetTooLarge)
+		// 2. Context errors (canceled, deadline exceeded)
+		// 3. Retryable errors that exhausted max retries (5xx server errors)
+
+		// Return context errors directly
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
-		if length > maxLength {
-			err := fmt.Errorf("download failed for %s, length %d is larger than expected %d", url, length, maxLength)
-			return nil, fmt.Errorf("%w: %v", ErrHTTPGetTooLarge, err)
+
+		// Return errors already wrapped with sentinel errors
+		if errors.Is(err, ErrHTTPGetError) || errors.Is(err, ErrHTTPGetTooLarge) {
+			return nil, err
 		}
-	}
-	// Although the size has been checked above, use a LimitReader in case
-	// the reported size is inaccurate.
-	data, err := io.ReadAll(io.LimitReader(res.Body, maxLength+1))
-	if err != nil {
+
+		// Check if this is a retryable 5xx error that exhausted retries
+		// These need to be wrapped with ErrHTTPGetError
+		errMsg := err.Error()
+		for code := 500; code < 600; code++ {
+			if strings.Contains(errMsg, "HTTP "+strconv.Itoa(code)) {
+				return nil, fmt.Errorf("%w: %v", ErrHTTPGetError, err)
+			}
+		}
+
+		// All other errors (client, network, etc.) return as-is
 		return nil, err
 	}
 
-	length = int64(len(data))
-	if int64(length) > maxLength {
-		err := fmt.Errorf("download failed for %s, length %d is larger than expected %d", url, length, maxLength)
-		return nil, fmt.Errorf("%w: %v", ErrHTTPGetTooLarge, err)
-	}
 	return data, nil
 }

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 type mockHTTPClient struct {
@@ -15,7 +17,57 @@ type mockHTTPClient struct {
 }
 
 func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	// Check if context is cancelled or timed out
+	if req.Context() != nil {
+		select {
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		default:
+		}
+	}
 	return m.response, m.err
+}
+
+// mockHTTPClientWithAttempts allows configuring different responses per attempt
+type mockHTTPClientWithAttempts struct {
+	responses []*http.Response
+	errors    []error
+	attempt   int
+	delays    []time.Duration
+}
+
+func (m *mockHTTPClientWithAttempts) Do(req *http.Request) (*http.Response, error) {
+	// Check if context is cancelled or timed out
+	if req.Context() != nil {
+		select {
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		default:
+		}
+	}
+
+	// Apply delay if configured for this attempt
+	if m.attempt < len(m.delays) && m.delays[m.attempt] > 0 {
+		select {
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		case <-time.After(m.delays[m.attempt]):
+		}
+	}
+
+	idx := m.attempt
+	m.attempt++
+
+	if idx >= len(m.responses) {
+		idx = len(m.responses) - 1
+	}
+
+	var err error
+	if idx < len(m.errors) {
+		err = m.errors[idx]
+	}
+
+	return m.responses[idx], err
 }
 
 func makeResponse(statusCode int, body string, headers map[string]string) *http.Response {
@@ -37,7 +89,7 @@ func TestHttpGET(t *testing.T) {
 			response: makeResponse(http.StatusOK, expectedBody, nil),
 		}
 
-		data, err := HttpGET(client, "http://example.com/test")
+		data, err := HttpGET(t.Context(), client, "http://example.com/test")
 		if err != nil {
 			t.Fatalf("HttpGET() error = %v, want nil", err)
 		}
@@ -53,7 +105,7 @@ func TestHttpGET(t *testing.T) {
 			response: makeResponse(http.StatusOK, expectedBody, nil),
 		}
 
-		data, err := HttpGET(client, "http://example.com/test", 10)
+		data, err := HttpGET(t.Context(), client, "http://example.com/test", 10)
 		if err != nil {
 			t.Fatalf("HttpGET() error = %v, want nil", err)
 		}
@@ -64,7 +116,7 @@ func TestHttpGET(t *testing.T) {
 	})
 
 	t.Run("uses default client when nil", func(t *testing.T) {
-		_, err := HttpGET(nil, "http://invalid-url-that-should-fail.local")
+		_, err := HttpGET(t.Context(), nil, "http://invalid-url-that-should-fail.local")
 		if err == nil {
 			t.Fatal("HttpGET() with nil client should fail on invalid URL")
 		}
@@ -75,7 +127,7 @@ func TestHttpGET(t *testing.T) {
 			response: makeResponse(http.StatusNotFound, "", nil),
 		}
 
-		_, err := HttpGET(client, "http://example.com/test")
+		_, err := HttpGET(t.Context(), client, "http://example.com/test")
 		if err == nil {
 			t.Fatal("HttpGET() error = nil, want error for non-200 status")
 		}
@@ -96,7 +148,7 @@ func TestHttpGET(t *testing.T) {
 			}),
 		}
 
-		_, err := HttpGET(client, "http://example.com/test", 100)
+		_, err := HttpGET(t.Context(), client, "http://example.com/test", 100)
 		if err == nil {
 			t.Fatal("HttpGET() error = nil, want error for content too large")
 		}
@@ -112,7 +164,7 @@ func TestHttpGET(t *testing.T) {
 			response: makeResponse(http.StatusOK, largeBody, nil),
 		}
 
-		_, err := HttpGET(client, "http://example.com/test", 100)
+		_, err := HttpGET(t.Context(), client, "http://example.com/test", 100)
 		if err == nil {
 			t.Fatal("HttpGET() error = nil, want error for content too large")
 		}
@@ -129,7 +181,7 @@ func TestHttpGET(t *testing.T) {
 			response: makeResponse(http.StatusOK, exactBody, nil),
 		}
 
-		data, err := HttpGET(client, "http://example.com/test", maxSize)
+		data, err := HttpGET(t.Context(), client, "http://example.com/test", maxSize)
 		if err != nil {
 			t.Fatalf("HttpGET() error = %v, want nil", err)
 		}
@@ -146,7 +198,7 @@ func TestHttpGET(t *testing.T) {
 			}),
 		}
 
-		_, err := HttpGET(client, "http://example.com/test")
+		_, err := HttpGET(t.Context(), client, "http://example.com/test")
 		if err == nil {
 			t.Fatal("HttpGET() error = nil, want error for invalid Content-Length")
 		}
@@ -158,7 +210,7 @@ func TestHttpGET(t *testing.T) {
 			err: expectedErr,
 		}
 
-		_, err := HttpGET(client, "http://example.com/test")
+		_, err := HttpGET(t.Context(), client, "http://example.com/test")
 		if err == nil {
 			t.Fatal("HttpGET() error = nil, want error")
 		}
@@ -171,7 +223,7 @@ func TestHttpGET(t *testing.T) {
 	t.Run("handles invalid URL", func(t *testing.T) {
 		client := &mockHTTPClient{}
 
-		_, err := HttpGET(client, "://invalid-url")
+		_, err := HttpGET(t.Context(), client, "://invalid-url")
 		if err == nil {
 			t.Fatal("HttpGET() error = nil, want error for invalid URL")
 		}
@@ -188,7 +240,7 @@ func TestHttpGET(t *testing.T) {
 			response: resp,
 		}
 
-		data, err := HttpGET(client, "http://example.com/binary")
+		data, err := HttpGET(t.Context(), client, "http://example.com/binary")
 		if err != nil {
 			t.Fatalf("HttpGET() error = %v, want nil", err)
 		}
@@ -210,7 +262,7 @@ func TestHttpGET(t *testing.T) {
 			response: makeResponse(http.StatusOK, expectedBody, nil),
 		}
 
-		data, err := HttpGET(client, "http://example.com/test", 10, 20, 30)
+		data, err := HttpGET(t.Context(), client, "http://example.com/test", 10, 20, 30)
 		if err != nil {
 			t.Fatalf("HttpGET() error = %v, want nil", err)
 		}
@@ -228,7 +280,7 @@ func TestHttpGET(t *testing.T) {
 			}),
 		}
 
-		data, err := HttpGET(client, "http://example.com/test", 100)
+		data, err := HttpGET(t.Context(), client, "http://example.com/test", 100)
 		if err != nil {
 			t.Fatalf("HttpGET() error = %v, want nil", err)
 		}
@@ -252,13 +304,251 @@ func TestHttpGET(t *testing.T) {
 			response: resp,
 		}
 
-		_, err := HttpGET(client, "http://example.com/test", 100)
+		_, err := HttpGET(t.Context(), client, "http://example.com/test", 100)
 		if err == nil {
 			t.Fatal("HttpGET() error = nil, want error for content exceeding max despite inaccurate Content-Length")
 		}
 
 		if !errors.Is(err, ErrHTTPGetTooLarge) {
 			t.Errorf("HttpGET() error should wrap ErrHTTPGetTooLarge, got %v", err)
+		}
+	})
+
+	t.Run("respects context timeout", func(t *testing.T) {
+		// Create a context with a very short timeout
+		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
+		defer cancel()
+
+		// Sleep to ensure the context times out
+		time.Sleep(10 * time.Millisecond)
+
+		client := &mockHTTPClient{
+			response: makeResponse(http.StatusOK, "test", nil),
+		}
+
+		_, err := HttpGET(ctx, client, "http://example.com/test")
+		if err == nil {
+			t.Fatal("HttpGET() error = nil, want error for timeout")
+		}
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("HttpGET() error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		// Create a context and cancel it immediately
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		client := &mockHTTPClient{
+			response: makeResponse(http.StatusOK, "test", nil),
+		}
+
+		_, err := HttpGET(ctx, client, "http://example.com/test")
+		if err == nil {
+			t.Fatal("HttpGET() error = nil, want error for cancelled context")
+		}
+
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("HttpGET() error = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("retries on 5xx server errors - 504 Gateway Timeout", func(t *testing.T) {
+		expectedBody := "success"
+		client := &mockHTTPClientWithAttempts{
+			responses: []*http.Response{
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusOK, expectedBody, nil),
+			},
+		}
+
+		data, err := HttpGET(context.Background(), client, "http://example.com/test")
+		if err != nil {
+			t.Fatalf("HttpGET() error = %v, want nil after retries", err)
+		}
+
+		if string(data) != expectedBody {
+			t.Errorf("HttpGET() = %q, want %q", data, expectedBody)
+		}
+
+		if client.attempt != 3 {
+			t.Errorf("Expected 3 attempts, got %d", client.attempt)
+		}
+	})
+
+	t.Run("retries on 5xx server errors - 500 Internal Server Error", func(t *testing.T) {
+		expectedBody := "success"
+		client := &mockHTTPClientWithAttempts{
+			responses: []*http.Response{
+				makeResponse(http.StatusInternalServerError, "", nil),
+				makeResponse(http.StatusInternalServerError, "", nil),
+				makeResponse(http.StatusOK, expectedBody, nil),
+			},
+		}
+
+		data, err := HttpGET(context.Background(), client, "http://example.com/test")
+		if err != nil {
+			t.Fatalf("HttpGET() error = %v, want nil after retries", err)
+		}
+
+		if string(data) != expectedBody {
+			t.Errorf("HttpGET() = %q, want %q", data, expectedBody)
+		}
+
+		if client.attempt != 3 {
+			t.Errorf("Expected 3 attempts, got %d", client.attempt)
+		}
+	})
+
+	t.Run("retries on 5xx server errors - 503 Service Unavailable", func(t *testing.T) {
+		expectedBody := "success"
+		client := &mockHTTPClientWithAttempts{
+			responses: []*http.Response{
+				makeResponse(http.StatusServiceUnavailable, "", nil),
+				makeResponse(http.StatusOK, expectedBody, nil),
+			},
+		}
+
+		data, err := HttpGET(context.Background(), client, "http://example.com/test")
+		if err != nil {
+			t.Fatalf("HttpGET() error = %v, want nil after retries", err)
+		}
+
+		if string(data) != expectedBody {
+			t.Errorf("HttpGET() = %q, want %q", data, expectedBody)
+		}
+
+		if client.attempt != 2 {
+			t.Errorf("Expected 2 attempts, got %d", client.attempt)
+		}
+	})
+
+	t.Run("fails after max retries on 5xx errors", func(t *testing.T) {
+		client := &mockHTTPClientWithAttempts{
+			responses: []*http.Response{
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+			},
+		}
+
+		_, err := HttpGET(context.Background(), client, "http://example.com/test")
+		if err == nil {
+			t.Fatal("HttpGET() error = nil, want error after max retries")
+		}
+
+		if !errors.Is(err, ErrHTTPGetError) {
+			t.Errorf("HttpGET() error should wrap ErrHTTPGetError, got %v", err)
+		}
+
+		if !strings.Contains(err.Error(), "HTTP 504") {
+			t.Errorf("HttpGET() error = %v, want error containing 'HTTP 504'", err)
+		}
+
+		// Should attempt 4 times (1 initial + 3 retries)
+		if client.attempt != 4 {
+			t.Errorf("Expected 4 attempts, got %d", client.attempt)
+		}
+	})
+
+	t.Run("does not retry on 4xx client errors", func(t *testing.T) {
+		client := &mockHTTPClientWithAttempts{
+			responses: []*http.Response{
+				makeResponse(http.StatusNotFound, "", nil),
+			},
+		}
+
+		_, err := HttpGET(context.Background(), client, "http://example.com/test")
+		if err == nil {
+			t.Fatal("HttpGET() error = nil, want error")
+		}
+
+		if !errors.Is(err, ErrHTTPGetError) {
+			t.Errorf("HttpGET() error should wrap ErrHTTPGetError, got %v", err)
+		}
+
+		// Should only attempt once, no retries for 4xx
+		if client.attempt != 1 {
+			t.Errorf("Expected 1 attempt, got %d", client.attempt)
+		}
+	})
+
+	t.Run("context timeout during retry backoff", func(t *testing.T) {
+		// Create a context with a timeout shorter than the total retry duration
+		// With 3 retries and exponential backoff (100ms, 200ms, 400ms), total would be ~700ms
+		// Set timeout to 50ms to ensure it times out during first backoff
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		client := &mockHTTPClientWithAttempts{
+			responses: []*http.Response{
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusOK, "success", nil),
+			},
+		}
+
+		_, err := HttpGET(ctx, client, "http://example.com/test")
+		if err == nil {
+			t.Fatal("HttpGET() error = nil, want error for timeout during retry")
+		}
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("HttpGET() error = %v, want context.DeadlineExceeded", err)
+		}
+
+		// Should have attempted at least once before timeout
+		if client.attempt < 1 {
+			t.Errorf("Expected at least 1 attempt, got %d", client.attempt)
+		}
+	})
+
+	t.Run("exponential backoff timing with 5xx errors", func(t *testing.T) {
+		// Save original config and restore after test
+		originalRandomization := DefaultBackoffConfig.RandomizationFactor
+		defer func() {
+			DefaultBackoffConfig.RandomizationFactor = originalRandomization
+		}()
+
+		// Disable randomization for predictable timing
+		DefaultBackoffConfig.RandomizationFactor = 0
+
+		client := &mockHTTPClientWithAttempts{
+			responses: []*http.Response{
+				makeResponse(http.StatusGatewayTimeout, "", nil),
+				makeResponse(http.StatusInternalServerError, "", nil),
+				makeResponse(http.StatusServiceUnavailable, "", nil),
+				makeResponse(http.StatusOK, "success", nil),
+			},
+		}
+
+		start := time.Now()
+		_, err := HttpGET(context.Background(), client, "http://example.com/test")
+		elapsed := time.Since(start)
+
+		if err != nil {
+			t.Fatalf("HttpGET() error = %v, want nil after retries", err)
+		}
+
+		// Expected backoff: 100ms + 200ms + 400ms = 700ms minimum
+		// Allow some margin for execution time
+		expectedMin := 700 * time.Millisecond
+		expectedMax := 1000 * time.Millisecond
+
+		if elapsed < expectedMin {
+			t.Errorf("HttpGET() completed too quickly: %v, expected at least %v", elapsed, expectedMin)
+		}
+
+		if elapsed > expectedMax {
+			t.Errorf("HttpGET() took too long: %v, expected at most %v", elapsed, expectedMax)
+		}
+
+		if client.attempt != 4 {
+			t.Errorf("Expected 4 attempts, got %d", client.attempt)
 		}
 	})
 }

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func JsonCompact(b []byte) ([]byte, error) {
+	var compactBuf bytes.Buffer
+	if err := json.Compact(&compactBuf, b); err != nil {
+		return nil, fmt.Errorf("failed to compact JSON: %w", err)
+	}
+	return compactBuf.Bytes(), nil
+}

--- a/internal/utils/json_test.go
+++ b/internal/utils/json_test.go
@@ -1,0 +1,88 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestJsonCompact(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "compact JSON with whitespace",
+			input:   []byte(`{"foo": "bar", "baz": 123}`),
+			want:    []byte(`{"foo":"bar","baz":123}`),
+			wantErr: false,
+		},
+		{
+			name:    "already compact JSON",
+			input:   []byte(`{"foo":"bar","baz":123}`),
+			want:    []byte(`{"foo":"bar","baz":123}`),
+			wantErr: false,
+		},
+		{
+			name:    "JSON with newlines and tabs",
+			input:   []byte("{\n\t\"foo\": \"bar\",\n\t\"baz\": 123\n}"),
+			want:    []byte(`{"foo":"bar","baz":123}`),
+			wantErr: false,
+		},
+		{
+			name:    "nested JSON with whitespace",
+			input:   []byte(`{"outer": {"inner": "value"}, "array": [1, 2, 3]}`),
+			want:    []byte(`{"outer":{"inner":"value"},"array":[1,2,3]}`),
+			wantErr: false,
+		},
+		{
+			name:    "empty JSON object",
+			input:   []byte(`{}`),
+			want:    []byte(`{}`),
+			wantErr: false,
+		},
+		{
+			name:    "empty JSON array",
+			input:   []byte(`[]`),
+			want:    []byte(`[]`),
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON - missing closing brace",
+			input:   []byte(`{"foo": "bar"`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON - trailing comma",
+			input:   []byte(`{"foo": "bar",}`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON - malformed",
+			input:   []byte(`not json at all`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			input:   []byte(``),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JsonCompact(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonCompact() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && string(got) != string(tt.want) {
+				t.Errorf("JsonCompact() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,5 +1,5 @@
 extensions = ["md"]
-timeout = 5
+timeout = 5 # in seconds
 header = { "accept" = "text/html" }
 accept = [
     "200",
@@ -11,5 +11,4 @@ exclude = [
     '^https://www\.st\.com',
     '^https://software\.intel\.com',
     '^https://(.*\.)?github(usercontent)?\.(com|io)',
-    '^http://invalid-url-that-should-fail\.local',
 ]

--- a/pkg/apiv1beta/api_test.go
+++ b/pkg/apiv1beta/api_test.go
@@ -1,7 +1,6 @@
 package apiv1beta
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -223,7 +222,6 @@ func TestCacheConfigValidation(t *testing.T) {
 }
 
 func TestVerifyTrustedBundleWithCustomTrustedRoot(t *testing.T) {
-	ctx := context.Background()
 
 	t.Run("verifies bundle with custom trusted root", func(t *testing.T) {
 		// Load all required test data
@@ -253,7 +251,7 @@ func TestVerifyTrustedBundleWithCustomTrustedRoot(t *testing.T) {
 		}
 
 		// Verify with custom trusted root (offline mode)
-		result, err := VerifyTrustedBundle(ctx, VerifyConfig{
+		result, err := VerifyTrustedBundle(t.Context(), VerifyConfig{
 			Bundle:            bundleData,
 			Checksum:          checksumData,
 			ChecksumSignature: checksumSigData,
@@ -297,7 +295,7 @@ func TestVerifyTrustedBundleWithCustomTrustedRoot(t *testing.T) {
 		}
 
 		// Try to verify with invalid JSON
-		_, err = VerifyTrustedBundle(ctx, VerifyConfig{
+		_, err = VerifyTrustedBundle(t.Context(), VerifyConfig{
 			Bundle:            bundleData,
 			Checksum:          checksumData,
 			ChecksumSignature: checksumSigData,

--- a/pkg/apiv1beta/assets.go
+++ b/pkg/apiv1beta/assets.go
@@ -195,7 +195,8 @@ func getAssetsFromGitHub(ctx context.Context, cfg assetsConfig) (*assets, error)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal provenance: %w", err)
 		}
-		response.provenance = provenanceJSON
+		compactJSON, _ := utils.JsonCompact(provenanceJSON) // should not fail
+		response.provenance = compactJSON
 	}
 
 	return response, nil

--- a/pkg/apiv1beta/trusted_bundle.go
+++ b/pkg/apiv1beta/trusted_bundle.go
@@ -165,12 +165,9 @@ func (tb *trustedBundle) Persist(optionalCachePath ...string) error {
 		return ErrCannotPersistTrustedBundle
 	}
 
-	cachePath, err := utils.OptionalArg(optionalCachePath)
-	if err != nil {
-		cachePath = cache.CacheDir()
-	}
-
-	cachePath = filepath.Clean(cachePath)
+	cachePath := filepath.Clean(
+		utils.OptionalArgWithDefault(optionalCachePath, cache.CacheDir()),
+	)
 
 	if !utils.DirExists(cachePath) {
 		if err := os.MkdirAll(cachePath, 0700); err != nil {
@@ -377,10 +374,9 @@ func Load(ctx context.Context, cfg LoadConfig) (TrustedBundle, error) {
 
 		// In offline mode, load trusted-root.json from cache
 		if cfg.OfflineMode {
-			trustedRootPath := filepath.Join(cfg.CachePath, CacheTrustedRootFilename)
-			trustedRootData, err = utils.ReadFile(trustedRootPath)
+			trustedRootData, err = cache.LoadFile(cache.TrustedRootFilename, cfg.CachePath)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read trusted root (required for offline mode): %w", err)
+				return nil, err
 			}
 		}
 

--- a/pkg/apiv1beta/trusted_bundle_test.go
+++ b/pkg/apiv1beta/trusted_bundle_test.go
@@ -1,7 +1,6 @@
 package apiv1beta
 
 import (
-	"context"
 	"crypto/x509"
 	"os"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestGetTrustedBundle(t *testing.T) {
-	ctx := context.Background()
 
 	t.Run("invalid vendor ID", func(t *testing.T) {
 		cfg := GetConfig{
@@ -23,7 +21,7 @@ func TestGetTrustedBundle(t *testing.T) {
 			},
 		}
 
-		_, err := GetTrustedBundle(ctx, cfg)
+		_, err := GetTrustedBundle(t.Context(), cfg)
 		if err == nil {
 			t.Fatal("Expected error for invalid vendor ID")
 		}
@@ -228,14 +226,13 @@ func TestGetVendors(t *testing.T) {
 }
 
 func TestLoadOfflineMode(t *testing.T) {
-	ctx := context.Background()
 
 	t.Run("loads bundle successfully in offline mode", func(t *testing.T) {
 		// Create cache with all required files including trusted-root.json
 		cacheDir := testutil.CreateCacheDir(t, nil)
 
 		// Load in offline mode
-		tb, err := Load(ctx, LoadConfig{
+		tb, err := Load(t.Context(), LoadConfig{
 			CachePath:   cacheDir,
 			OfflineMode: true,
 		})
@@ -295,7 +292,7 @@ func TestLoadOfflineMode(t *testing.T) {
 		}
 
 		// Try to load in offline mode - should fail
-		_, err = Load(ctx, LoadConfig{
+		_, err = Load(t.Context(), LoadConfig{
 			CachePath:   tmpDir,
 			OfflineMode: true,
 		})
@@ -307,7 +304,7 @@ func TestLoadOfflineMode(t *testing.T) {
 	t.Run("fails when offline mode requires local cache", func(t *testing.T) {
 		cacheDir := testutil.CreateCacheDir(t, nil)
 
-		_, err := Load(ctx, LoadConfig{
+		_, err := Load(t.Context(), LoadConfig{
 			CachePath:         cacheDir,
 			OfflineMode:       true,
 			DisableLocalCache: true,
@@ -327,7 +324,7 @@ func TestLoadOfflineMode(t *testing.T) {
 		}`)
 		cacheDir := testutil.CreateCacheDir(t, configData)
 
-		tb, err := Load(ctx, LoadConfig{
+		tb, err := Load(t.Context(), LoadConfig{
 			CachePath:   cacheDir,
 			OfflineMode: true,
 		})

--- a/tests/integration/apiv1beta_test.go
+++ b/tests/integration/apiv1beta_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -24,15 +23,13 @@ func TestVerifyTrustedBundle(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	ctx := context.Background()
-
 	t.Run("VerifyWithAutoDetectedMetadataAndDownloadedChecksums", func(t *testing.T) {
 		if testing.Short() {
 			t.Skip("Skipping integration test in short mode")
 		}
 
 		// First download a bundle
-		trustedBundle, err := apiv1beta.GetTrustedBundle(ctx, apiv1beta.GetConfig{
+		trustedBundle, err := apiv1beta.GetTrustedBundle(t.Context(), apiv1beta.GetConfig{
 			Date:       testutil.BundleVersion,
 			SkipVerify: true,
 		})
@@ -41,7 +38,7 @@ func TestVerifyTrustedBundle(t *testing.T) {
 		}
 
 		// Now verify it with auto-detected metadata and auto-downloaded checksums
-		_, err = apiv1beta.VerifyTrustedBundle(ctx, apiv1beta.VerifyConfig{
+		_, err = apiv1beta.VerifyTrustedBundle(t.Context(), apiv1beta.VerifyConfig{
 			Bundle: trustedBundle.GetRaw(),
 		})
 		if err != nil {
@@ -50,7 +47,7 @@ func TestVerifyTrustedBundle(t *testing.T) {
 	})
 
 	t.Run("EmptyBundleError", func(t *testing.T) {
-		_, err := apiv1beta.VerifyTrustedBundle(ctx, apiv1beta.VerifyConfig{
+		_, err := apiv1beta.VerifyTrustedBundle(t.Context(), apiv1beta.VerifyConfig{
 			Bundle: []byte{},
 		})
 		if err == nil {
@@ -64,7 +61,7 @@ func TestVerifyTrustedBundle(t *testing.T) {
 
 	t.Run("InvalidBundleMetadata", func(t *testing.T) {
 		// Bundle with metadata that has Date but no Commit
-		_, err := apiv1beta.VerifyTrustedBundle(ctx, apiv1beta.VerifyConfig{
+		_, err := apiv1beta.VerifyTrustedBundle(t.Context(), apiv1beta.VerifyConfig{
 			Bundle: []byte("dummy"),
 			BundleMetadata: &bundle.Metadata{
 				Date:   testutil.BundleVersion,
@@ -82,7 +79,7 @@ func TestVerifyTrustedBundle(t *testing.T) {
 
 	t.Run("InvalidBundleContent", func(t *testing.T) {
 		// Bundle without proper metadata headers should fail parsing
-		_, err := apiv1beta.VerifyTrustedBundle(ctx, apiv1beta.VerifyConfig{
+		_, err := apiv1beta.VerifyTrustedBundle(t.Context(), apiv1beta.VerifyConfig{
 			Bundle: []byte("invalid bundle content without metadata"),
 		})
 		if err == nil {
@@ -100,7 +97,6 @@ func TestGetTrustedBundle(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	ctx := context.Background()
 	t.Parallel()
 
 	t.Run("fetch and parse latest bundle", func(t *testing.T) {
@@ -112,7 +108,7 @@ func TestGetTrustedBundle(t *testing.T) {
 			CachePath: t.TempDir(),
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("GetTrustedBundle() error = %v", err)
 		}
@@ -158,7 +154,7 @@ func TestGetTrustedBundle(t *testing.T) {
 			CachePath: t.TempDir(),
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("GetTrustedBundle() error = %v", err)
 		}
@@ -178,7 +174,7 @@ func TestGetTrustedBundle(t *testing.T) {
 			CachePath: t.TempDir(),
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("GetTrustedBundle() error = %v", err)
 		}
@@ -201,7 +197,7 @@ func TestGetTrustedBundle(t *testing.T) {
 			CachePath: t.TempDir(),
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("GetTrustedBundle() error = %v", err)
 		}
@@ -245,7 +241,7 @@ func TestGetTrustedBundle(t *testing.T) {
 			CachePath: t.TempDir(),
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("GetTrustedBundle() error = %v", err)
 		}
@@ -268,7 +264,7 @@ func TestGetTrustedBundle(t *testing.T) {
 			CachePath: t.TempDir(),
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("GetTrustedBundle() error = %v", err)
 		}
@@ -309,7 +305,6 @@ func TestTrustedBundle_ThreadSafety(t *testing.T) {
 		t.Skip("Skipping thread safety test in short mode")
 	}
 
-	ctx := context.Background()
 	cfg := apiv1beta.GetConfig{
 		SkipVerify: true,
 		AutoUpdate: apiv1beta.AutoUpdateConfig{
@@ -317,7 +312,7 @@ func TestTrustedBundle_ThreadSafety(t *testing.T) {
 		},
 	}
 
-	tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+	tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 	if err != nil {
 		t.Fatalf("GetTrustedBundle() error = %v", err)
 	}
@@ -373,8 +368,6 @@ func TestSmartCache(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	ctx := context.Background()
-
 	t.Run("first fetch downloads and caches bundle", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
@@ -388,7 +381,7 @@ func TestSmartCache(t *testing.T) {
 			},
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("First GetTrustedBundle() error = %v", err)
 		}
@@ -434,7 +427,7 @@ func TestSmartCache(t *testing.T) {
 			},
 		}
 
-		tb1, err := apiv1beta.GetTrustedBundle(ctx, cfg1)
+		tb1, err := apiv1beta.GetTrustedBundle(t.Context(), cfg1)
 		if err != nil {
 			t.Fatalf("First GetTrustedBundle() error = %v", err)
 		}
@@ -461,7 +454,7 @@ func TestSmartCache(t *testing.T) {
 			},
 		}
 
-		tb2, err := apiv1beta.GetTrustedBundle(ctx, cfg2)
+		tb2, err := apiv1beta.GetTrustedBundle(t.Context(), cfg2)
 		if err != nil {
 			t.Fatalf("Second GetTrustedBundle() error = %v", err)
 		}
@@ -497,7 +490,7 @@ func TestSmartCache(t *testing.T) {
 			},
 		}
 
-		tb1, err := apiv1beta.GetTrustedBundle(ctx, cfg1)
+		tb1, err := apiv1beta.GetTrustedBundle(t.Context(), cfg1)
 		if err != nil {
 			t.Fatalf("First GetTrustedBundle() error = %v", err)
 		}
@@ -513,7 +506,7 @@ func TestSmartCache(t *testing.T) {
 			},
 		}
 
-		tb2, err := apiv1beta.GetTrustedBundle(ctx, cfg2)
+		tb2, err := apiv1beta.GetTrustedBundle(t.Context(), cfg2)
 		if err != nil {
 			t.Fatalf("Second GetTrustedBundle() error = %v", err)
 		}
@@ -556,7 +549,7 @@ func TestSmartCache(t *testing.T) {
 			},
 		}
 
-		tb, err := apiv1beta.GetTrustedBundle(ctx, cfg)
+		tb, err := apiv1beta.GetTrustedBundle(t.Context(), cfg)
 		if err != nil {
 			t.Fatalf("GetTrustedBundle() error = %v", err)
 		}
@@ -577,7 +570,6 @@ func TestLoad(t *testing.T) {
 
 	t.Parallel()
 
-	ctx := context.Background()
 	// cfg := apiv1beta.CacheConfig{
 	// 	Version:       testutil.BundleVersion,
 	// 	AutoUpdate:    &apiv1beta.AutoUpdateConfig{},
@@ -592,7 +584,7 @@ func TestLoad(t *testing.T) {
 	// t.Run("load from cache without network requests", func(t *testing.T) {
 	// 	tmpDir := testutil.CreateCacheDir(t, configData)
 
-	// 	tb, err := apiv1beta.Load(ctx, apiv1beta.LoadConfig{
+	// 	tb, err := apiv1beta.Load(t.Context(), apiv1beta.LoadConfig{
 	// 		CachePath:  tmpDir,
 	// 		SkipVerify: false,
 	// 	})
@@ -625,7 +617,7 @@ func TestLoad(t *testing.T) {
 	// 	}
 
 	// 	// Load should fail because provenance is missing
-	// 	_, err := apiv1beta.Load(ctx, apiv1beta.LoadConfig{
+	// 	_, err := apiv1beta.Load(t.Context(), apiv1beta.LoadConfig{
 	// 		CachePath:  tmpDir,
 	// 		SkipVerify: false,
 	// 	})
@@ -639,7 +631,7 @@ func TestLoad(t *testing.T) {
 	// })
 
 	// t.Run("load with missing cache directory", func(t *testing.T) {
-	// 	_, err := apiv1beta.Load(ctx, apiv1beta.LoadConfig{
+	// 	_, err := apiv1beta.Load(t.Context(), apiv1beta.LoadConfig{
 	// 		CachePath: "/nonexistent/directory",
 	// 	})
 	// 	if err == nil {
@@ -670,7 +662,7 @@ func TestLoad(t *testing.T) {
 		tmpDir := testutil.CreateCacheDir(t, configData)
 
 		// Load the bundle from cache (old version)
-		tb, err := apiv1beta.Load(ctx, apiv1beta.LoadConfig{
+		tb, err := apiv1beta.Load(t.Context(), apiv1beta.LoadConfig{
 			CachePath:  tmpDir,
 			SkipVerify: true,
 		})
@@ -727,14 +719,13 @@ func TestSave(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	ctx := context.Background()
 	t.Parallel()
 
 	t.Run("save bundle with all verification assets", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		// Save the latest bundle
-		resp, err := apiv1beta.Save(ctx, apiv1beta.SaveConfig{
+		resp, err := apiv1beta.Save(t.Context(), apiv1beta.SaveConfig{
 			CachePath: tmpDir,
 		})
 		if err != nil {
@@ -787,7 +778,7 @@ func TestSave(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		// Save a specific date with vendor filter
-		resp, err := apiv1beta.Save(ctx, apiv1beta.SaveConfig{
+		resp, err := apiv1beta.Save(t.Context(), apiv1beta.SaveConfig{
 			Date:      testutil.BundleVersion,
 			VendorIDs: []apiv1beta.VendorID{apiv1beta.IFX, apiv1beta.NTC},
 			CachePath: tmpDir,
@@ -815,7 +806,7 @@ func TestSave(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		// Save and persist
-		resp, err := apiv1beta.Save(ctx, apiv1beta.SaveConfig{
+		resp, err := apiv1beta.Save(t.Context(), apiv1beta.SaveConfig{
 			Date:      testutil.BundleVersion,
 			CachePath: tmpDir,
 		})
@@ -864,7 +855,7 @@ func TestSave(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		// Save bundle
-		resp, err := apiv1beta.Save(ctx, apiv1beta.SaveConfig{
+		resp, err := apiv1beta.Save(t.Context(), apiv1beta.SaveConfig{
 			Date:      testutil.BundleVersion,
 			CachePath: tmpDir,
 		})
@@ -879,7 +870,7 @@ func TestSave(t *testing.T) {
 		}
 
 		// Load the saved bundle from cache
-		tb, err := apiv1beta.Load(ctx, apiv1beta.LoadConfig{
+		tb, err := apiv1beta.Load(t.Context(), apiv1beta.LoadConfig{
 			CachePath:  cacheDir,
 			SkipVerify: false, // Verify using cached assets
 		})

--- a/tests/integration/cli/bundle/download_test.go
+++ b/tests/integration/cli/bundle/download_test.go
@@ -2,7 +2,6 @@ package bundle_test
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
@@ -50,7 +49,7 @@ func TestDownloadCommand(t *testing.T) {
 			// Run download in a goroutine
 			errCh := make(chan error, 1)
 			go func() {
-				errCh <- download.Run(context.Background(), opts)
+				errCh <- download.Run(t.Context(), opts)
 			}()
 
 			// Read output

--- a/tests/integration/cli/bundle/list_test.go
+++ b/tests/integration/cli/bundle/list_test.go
@@ -1,7 +1,6 @@
 package bundle_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -85,7 +84,7 @@ func TestListCommand(t *testing.T) {
 			cmd := list.NewCommand()
 			cmd.SetArgs(tt.args)
 
-			err := cmd.ExecuteContext(context.Background())
+			err := cmd.ExecuteContext(t.Context())
 
 			if tt.wantErr {
 				if err == nil {
@@ -120,7 +119,7 @@ func TestListCommandOutput(t *testing.T) {
 	cmd := list.NewCommand()
 	cmd.SetArgs([]string{"--limit", "3"})
 
-	err := cmd.ExecuteContext(context.Background())
+	err := cmd.ExecuteContext(t.Context())
 	if err != nil {
 		t.Skipf("skipping output test due to network error: %v", err)
 		return
@@ -141,7 +140,7 @@ func TestListCommandWithRealAPI(t *testing.T) {
 		SortOrder: github.SortOrderDesc,
 	}
 
-	releases, err := client.GetReleases(context.Background(), github.SourceRepo, opts)
+	releases, err := client.GetReleases(t.Context(), github.SourceRepo, opts)
 	if err != nil {
 		t.Fatalf("failed to fetch releases: %v", err)
 	}

--- a/tests/integration/cli/bundle/save_test.go
+++ b/tests/integration/cli/bundle/save_test.go
@@ -1,7 +1,6 @@
 package bundle_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -111,7 +110,7 @@ func TestSaveCommand(t *testing.T) {
 			}
 
 			// Run the save command
-			err := save.Run(context.Background(), &tt.opts)
+			err := save.Run(t.Context(), &tt.opts)
 
 			// Check error expectation
 			if tt.expectError && err == nil {
@@ -146,13 +145,13 @@ func TestSaveCommandForceFlag(t *testing.T) {
 			LocalCache: false,
 		}
 
-		err := save.Run(context.Background(), &opts)
+		err := save.Run(t.Context(), &opts)
 		if err != nil {
 			t.Fatalf("first save failed: %v", err)
 		}
 
 		// Second save with force flag should succeed
-		err = save.Run(context.Background(), &opts)
+		err = save.Run(t.Context(), &opts)
 		if err != nil {
 			t.Fatalf("second save with force flag failed: %v", err)
 		}

--- a/tests/integration/cli/config/add_test.go
+++ b/tests/integration/cli/config/add_test.go
@@ -148,7 +148,7 @@ vendors:
 			tt.opts.ConfigPath = configPath
 
 			// Run the add command
-			err := certificates.RunAdd(&tt.opts)
+			err := certificates.Run(t.Context(), &tt.opts)
 
 			// Check error expectation
 			if tt.expectError && err == nil {
@@ -298,7 +298,7 @@ vendors:
 				Fingerprint:   tt.fingerprint,
 			}
 
-			err := certificates.RunAdd(opts)
+			err := certificates.Run(t.Context(), opts)
 
 			if tt.expectError {
 				if err == nil {

--- a/tests/integration/cosign_test.go
+++ b/tests/integration/cosign_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,12 +52,11 @@ func TestCosignVerification(t *testing.T) {
 		t.Fatalf("Failed to parse bundle metadata: %v", err)
 	}
 
-	ctx := context.Background()
 	cfg := testPolicyConfig(metadata)
 	verifierCfg := verifier.Config{}
 
 	t.Run("VerifyValidSignature", func(t *testing.T) {
-		result, err := cosign.VerifyChecksum(ctx, cfg, verifierCfg, checksumData, signatureData, bundleData, testutil.BundleFile)
+		result, err := cosign.VerifyChecksum(t.Context(), cfg, verifierCfg, checksumData, signatureData, bundleData, testutil.BundleFile)
 		if err != nil {
 			t.Fatalf("Expected successful verification, got error: %v", err)
 		}
@@ -72,7 +70,7 @@ func TestCosignVerification(t *testing.T) {
 		invalidData := []byte("invalid content\n")
 
 		// Verification should fail because checksum doesn't match
-		_, err = cosign.VerifyChecksum(ctx, cfg, verifierCfg, checksumData, signatureData, invalidData, testutil.BundleFile)
+		_, err = cosign.VerifyChecksum(t.Context(), cfg, verifierCfg, checksumData, signatureData, invalidData, testutil.BundleFile)
 		if err == nil {
 			t.Fatal("Expected verification to fail with invalid checksum, but it succeeded")
 		}
@@ -85,7 +83,7 @@ func TestCosignVerification(t *testing.T) {
 		// Use invalid signature data
 		invalidSignature := []byte("invalid json")
 
-		_, err = cosign.VerifyChecksum(ctx, cfg, verifierCfg, checksumData, invalidSignature, bundleData, testutil.BundleFile)
+		_, err = cosign.VerifyChecksum(t.Context(), cfg, verifierCfg, checksumData, invalidSignature, bundleData, testutil.BundleFile)
 		if err == nil {
 			t.Fatal("Expected verification to fail with invalid signature data, but it succeeded")
 		}

--- a/tests/integration/internal/verify_test.go
+++ b/tests/integration/internal/verify_test.go
@@ -1,7 +1,6 @@
 package internal_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/loicsikidi/tpm-ca-certificates/internal/bundle/verifier"
@@ -81,7 +80,7 @@ func TestVerifyIntegration(t *testing.T) {
 
 	// Step 3: Verify bundle
 	t.Log("Step 3: Verifying bundle...")
-	result, err := v.Verify(context.Background(), bundleData, checksumData, checksumSigData, provenanceData, bundleDigest)
+	result, err := v.Verify(t.Context(), bundleData, checksumData, checksumSigData, provenanceData, bundleDigest)
 	if err != nil {
 		t.Fatalf("Verification failed: %v", err)
 	}
@@ -141,7 +140,7 @@ func TestVerifyWithInvalidCommit(t *testing.T) {
 	}
 
 	// Verification should fail due to commit mismatch
-	_, err = v.Verify(context.Background(), bundleData, checksumData, checksumSigData, provenanceData, bundleDigest)
+	_, err = v.Verify(t.Context(), bundleData, checksumData, checksumSigData, provenanceData, bundleDigest)
 	if err == nil {
 		t.Error("Expected verification to fail with wrong commit, but it succeeded")
 	} else {
@@ -191,7 +190,7 @@ func TestVerifyWithInvalidDate(t *testing.T) {
 	}
 
 	// Verification should fail due to date mismatch
-	_, err = v.Verify(context.Background(), bundleData, checksumData, checksumSigData, provenanceData, bundleDigest)
+	_, err = v.Verify(t.Context(), bundleData, checksumData, checksumSigData, provenanceData, bundleDigest)
 	if err == nil {
 		t.Error("Expected verification to fail with wrong date, but it succeeded")
 	} else {


### PR DESCRIPTION
Notes:
  * migrate to a cleaner version if OptionalArg
  * use JSON compact function for large output files (ie. attestation or TUF trusted root)
  * add ctx to utils.HttpGET
  * add backoff policy in utils.HttpGET
  * update all tests to use `t.Context()` instead of `context.Background()`