### PR TITLE
rot(AMD): add 3 new root certificates

### DIFF
--- a/.tpm-roots.yaml
+++ b/.tpm-roots.yaml
@@ -1,6 +1,24 @@
 ---
 version: "alpha"
 vendors:
+    - id: "AMD"
+      name: "AMD"
+      certificates:
+        - name: "AMD Pluton Global Factory ICA"
+          url: "https://ftpm.amd.com/hsp/ica/AMD-Pluton-Global-Factory-ICA.crt"
+          validation:
+            fingerprint:
+                sha256: "59:3A:17:94:F9:E1:74:76:C7:AD:42:7D:29:08:A9:7C:45:14:51:C9:E0:93:9F:DC:80:D5:D6:62:C2:32:D4:01"
+        - name: "AMDTPM ECC"
+          url: "https://ftpm.amd.com/pki/aia/23452201D41C5AB064032BD23F158FEF"
+          validation:
+            fingerprint:
+                sha256: "C2:CB:57:BF:72:3C:17:4F:16:6C:5A:A1:DC:64:16:09:81:05:4B:EE:18:C7:0E:B1:DE:BF:C1:51:8A:FA:92:D2"
+        - name: "AMDTPM RSA"
+          url: "https://ftpm.amd.com/pki/aia/264D39A23CEB5D5B49D610044EEBD121"
+          validation:
+            fingerprint:
+                sha256: "B7:3F:14:DE:A3:BD:AA:0B:E8:74:40:DE:3F:C7:18:C7:71:F2:CB:F8:B7:B2:23:1C:6E:A2:28:D3:B2:08:60:EF"
     - id: "IFX"
       name: "Infineon"
       certificates:

--- a/src/AMD/README.md
+++ b/src/AMD/README.md
@@ -1,0 +1,51 @@
+# AMD
+
+## Overview
+
+AMD provides TPM certificates through their firmware TPM (fTPM) and Pluton implementations.
+
+## Certificate Inventory
+
+| Certificate Name | Type | Source | Does the source reference a fingerprint? |
+|------------------|------|--------|:----------------------------------------:|
+| AMDTPM ECC | Root | AIA extraction from intermediate certificates from Microsoft TPM bundle | No |
+| AMDTPM RSA | Root | AIA extraction from intermediate certificates from Microsoft TPM bundle | No |
+| AMD Pluton Global Factory ICA | Root | AIA extraction from intermediate certificates from Microsoft TPM bundle | No |
+
+> [!IMPORTANT]
+> `AMD Pluton Global Factory ICA` is currently classified as root certificate because we did not find a public URL (owned by AMD) giving its issuer (i.e. **CN=AMD Root CA R4**).
+
+## Discovery Process
+
+### AMDTPM RSA
+
+**Discovery Method**:
+1. Retrieved the certificate bundle maintained by Microsoft ([available here](https://learn.microsoft.com/en-us/windows-server/security/guarded-fabric-shielded-vm/guarded-fabric-install-trusted-tpm-root-certificates))
+2. Selected an intermediate certificate issued by AMD from the bundle
+3. Extracted the Authority Information Access (AIA) extension from the intermediate certificate
+4. The AIA extension contained a URL pointing to the root certificate: `http://ftpm.amd.com/pki/aia/264D39A23CEB5D5B49D610044EEBD121`
+5. Downloaded the certificate from the AIA URL
+
+Since the domain **ftpm.amd.com** is owned by Advanced Micro Devices, Inc., we can reasonably assume this certificate is legitimate.
+
+### AMDTPM ECC
+
+**Discovery Method**:
+1. Retrieved the certificate bundle maintained by Microsoft
+2. Selected an intermediate certificate issued by AMD from the bundle
+3. Extracted the Authority Information Access (AIA) extension from the intermediate certificate
+4. The AIA extension contained a URL pointing to the root certificate: `http://ftpm.amd.com/pki/aia/23452201D41C5AB064032BD23F158FEF`
+5. Downloaded the certificate from the AIA URL
+
+Since the domain **ftpm.amd.com** is owned by Advanced Micro Devices, Inc., we can reasonably assume this certificate is legitimate.
+
+### AMDTPM ECC
+
+**Discovery Method**:
+1. Retrieved the certificate bundle maintained by Microsoft
+2. Selected an intermediate certificate issued by AMD from the bundle
+3. Extracted the Authority Information Access (AIA) extension from the intermediate certificate
+4. The AIA extension contained a URL pointing to the root certificate: `http://ftpm.amd.com/pki/aia/23452201D41C5AB064032BD23F158FEF`
+5. Downloaded the certificate from the AIA URL
+
+Since the domain **ftpm.amd.com** is owned by Advanced Micro Devices, Inc., we can reasonably assume this certificate is legitimate.

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ This directory contains the evidence and documentation proving how the URLs for 
 
 | Vendor ID | Vendor Name | Documentation | Accessibility Score |
 |-----------|-------------|:-------------:|:-------------------:|
+| AMD | AMD | [README](AMD/) | C |
 | INTC | Intel | [README](INTC/) | C |
 | IFX | Infineon | [README](IFX/) | B |
 | MSFT | Microsoft | [README](MSFT/) | C |


### PR DESCRIPTION
Note: exceptionaly "AMD Pluton Global Factory ICA" is promoted as a root certificate until we are able to find a proper URL to get "AMD Root CA R4". Microsoft's bundle also considers "AMD Pluton Global Factory ICA" as a root certificate in its classification.