### PR TITLE
rot(IFX): migrate ECC Root CA to pki URL

### DIFF
--- a/.tpm-roots.yaml
+++ b/.tpm-roots.yaml
@@ -23,7 +23,7 @@ vendors:
       name: "Infineon"
       certificates:
         - name: "Infineon OPTIGA(TM) ECC Root CA"
-          url: "https://www.infineon.com/assets/row/public/documents/30/67/infineon-optigatm-trust-ecc-root-ca-certificates-en.cer"
+          url: "https://pki.infineon.com/OptigaEccRootCA/OptigaEccRootCA.crt"
           validation:
             fingerprint:
                 sha256: "CF:EB:02:FE:CD:55:AD:7A:73:C6:E1:D1:19:85:D4:C4:7D:EE:24:8A:B6:3D:CB:66:09:1A:24:89:66:04:43:C3"

--- a/internal/testutil/testdata/.tpm-roots.yaml
+++ b/internal/testutil/testdata/.tpm-roots.yaml
@@ -5,7 +5,7 @@ vendors:
       name: "Infineon"
       certificates:
         - name: "Infineon OPTIGA(TM) ECC Root CA"
-          url: "https://www.infineon.com/assets/row/public/documents/30/67/infineon-optigatm-trust-ecc-root-ca-certificates-en.cer"
+          url: "https://pki.infineon.com/OptigaEccRootCA/OptigaEccRootCA.crt"
           validation:
             fingerprint:
                 sha256: "CF:EB:02:FE:CD:55:AD:7A:73:C6:E1:D1:19:85:D4:C4:7D:EE:24:8A:B6:3D:CB:66:09:1A:24:89:66:04:43:C3"

--- a/src/IFX/README.md
+++ b/src/IFX/README.md
@@ -34,6 +34,9 @@ This turned out to be a real treasure hunt!
 - **Web Page**: https://www.infineon.com/design-resources/platforms/optiga-software-tools/optiga-tpm-certificates/optiga-trust-certificates
 - **Screenshot Reference**: ![infineon_website.png](infineon_website.png)
 
+> [!NOTE]
+> **Erratum (2026-01-22)**: The certificate URL has been switched from the documentation endpoint to the PKI API endpoint (`https://pki.infineon.com/OptigaEccRootCA/OptigaEccRootCA.crt`). The previous documentation endpoint returns an HTTP 202 error. This change harmonizes the configuration with other Infineon root certificates, all of which use the PKI API endpoints.
+
 ### Infineon OPTIGA(TM) RSA Root CA
 
 **Discovery Method**:


### PR DESCRIPTION
Note: this is motivated to the fact that previous URL now returns 202 http status. The hash digest doesn't change.