### PR TITLE
perf: improve GetDefaultTUFOptions logic

### DIFF
--- a/internal/transparency/utils/verifier/verifier.go
+++ b/internal/transparency/utils/verifier/verifier.go
@@ -73,6 +73,15 @@ func GetDefaultTUFOptions(optionalClient ...utils.HTTPClient) *tuf.Options {
 	// Store TUF cache in a directory owned by tpmtb for better isolation
 	opts.CachePath = filepath.Join(cache.CacheDir(), ".sigstore", "root")
 
+	// Attempt to load the trusted root from the local cache if it exists
+	// Note: it can happen that the `root.json` included in `tuf` package is outdated
+	rootPath := filepath.Join(opts.CachePath, tuf.URLToPath("https://tuf-repo-cdn.sigstore.dev"), "root.json")
+	if utils.FileExists(rootPath) {
+		if b, err := utils.ReadFile(rootPath); err == nil {
+			opts.Root = b
+		}
+	}
+
 	// Rely on cache to avoid unnecessary network calls
 	// the package will automatically refresh the cache once key material expires
 	opts.ForceCache = true


### PR DESCRIPTION
Note: this little change allow to use 'root.json' if the file is available in the cache. This strategy fix the behavior where the `root.json` included is tuf package has higher precedence over the version downloaded from the remote. In some circumstance the content embedded in tuf package is outdated and should be muted.