### PR TITLE
perf: add parallelization to some tests

### DIFF
--- a/tests/integration/cli/bundle/generate_test.go
+++ b/tests/integration/cli/bundle/generate_test.go
@@ -76,6 +76,8 @@ func TestGenerateCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			outputPath := tmpDir + "/" + tt.outputFilename
 
 			opts := &generate.Opts{
@@ -160,11 +162,4 @@ func TestGenerateCommand_InvalidType(t *testing.T) {
 	}
 
 	t.Logf("✓ Correctly rejected invalid bundle type")
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/tests/integration/cli/bundle/save_test.go
+++ b/tests/integration/cli/bundle/save_test.go
@@ -104,6 +104,8 @@ func TestSaveCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			tmpDir := t.TempDir()
 			if tt.opts.OutputDir == "" {
 				tt.opts.OutputDir = tmpDir


### PR DESCRIPTION
Note: the idea is to run integration test faster using 't.Parallel()' where it's possible.