### PR TITLE
Add CN=PRG-RPL as AMD PRG-RPL EK ICA to the intermediate bundle

### DIFF
--- a/.tpm-intermediates.yaml
+++ b/.tpm-intermediates.yaml
@@ -4,6 +4,11 @@ vendors:
     - id: "AMD"
       name: "AMD"
       certificates:
+        - name: "AMD PRG-RPL EK ICA"
+          url: "https://ftpm.amd.com/pki/aia/9DE34E7EF9C15FA479A9F398BC865D60"
+          validation:
+            fingerprint:
+                sha256: "F1:C6:64:B0:27:C9:FA:F0:7F:2D:52:3D:6C:84:9F:91:27:19:15:73:E9:F3:25:D6:C4:C7:C5:6A:76:A8:FF:CC"
         - name: "AMD Pluton Per-Product Factory FIPS EK ICA DFID00B20F00"
           url: "https://ftpm.amd.com/hsp/ica/00B20F00-fips.crt"
           validation:


### PR DESCRIPTION
Adds CN=PRG-RPL as AMD PRG-RPL EK ICA to the intermediate bundle.

This intermediate is issued by `CN=AMDTPM` (already present as `AMDTPM RSA` in the root bundle) and signs EK certificates on legacy AMD fTPM devices (e.g. Ryzen 9 7950X, firmware 6.32.6, spec rev 1.59)
Without this entry, validation fails even after successfully fetching the EK cert from `ftpm.amd.com` the chain is complete but the intermediate is not trusted

Documented in issue #95. The cert is publicly accessible via AIA on `ftpm.amd.com`. The URL and SHA-256 fingerprint were verified against the certificate retrieved from a live AMD fTPM device.

The `CN=AMDTPM` → `CN=PRG-RPL` → EK chain is entirely separate from the AMD Pluton hierarchy (`AMD Root CA R4`).

```
curl -s http://ftpm.amd.com/pki/aia/9DE34E7EF9C15FA479A9F398BC865D60 | \
  openssl x509 -inform DER -noout -fingerprint -sha256
```
Expected: `F1:C6:64:B0:27:C9:FA:F0:7F:2D:52:3D:6C:84:9F:91:27:19:15:73:E9:F3:25:D6:C4:C7:C5:6A:76:A8:FF:CC`

~~Closes #95~~
Related to #95