### PR TITLE
ci: move cert-autodiscory in a dedicated job

### DIFF
--- a/.github/workflows/cert-autodiscovery.yaml
+++ b/.github/workflows/cert-autodiscovery.yaml
@@ -1,0 +1,62 @@
+name: Certificate Autodiscovery
+on:
+  schedule: # daily at 19:00 UTC
+    - cron: '0 19 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+permissions: {}
+
+jobs:
+  vendor-coverage:
+    name: Verify ${{ matrix.vendor }} ${{ matrix.cert-type }} Certificates Coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        vendor: [ifx, stm]
+        cert-type: [root, intermediate]
+        include:
+          - vendor: ifx
+            vendor-id: IFX
+            cert-type: root
+            config-file: .tpm-roots.yaml
+          - vendor: ifx
+            vendor-id: IFX
+            cert-type: intermediate
+            config-file: .tpm-intermediates.yaml
+          - vendor: nsg
+            vendor-id: NSG
+            cert-type: root
+            config-file: .tpm-roots.yaml
+          - vendor: nsg
+            vendor-id: NSG
+            cert-type: intermediate
+            config-file: .tpm-intermediates.yaml
+          - vendor: stm
+            vendor-id: STM
+            cert-type: root
+            config-file: .tpm-roots.yaml
+          - vendor: stm
+            vendor-id: STM
+            cert-type: intermediate
+            config-file: .tpm-intermediates.yaml
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@0b0e072294b088b73964f1d72dfdac0951439dbd # v31.8.4
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check ${{ matrix.vendor }} ${{ matrix.cert-type }} coverage
+        run: |
+          echo "Renaming Go scripts..."
+          mv scripts/predict-new-urls.gos scripts/predict-new-urls.go
+          mv scripts/verify-coverage.gos scripts/verify-coverage.go
+          echo "Predicting available ${{ matrix.vendor }} ${{ matrix.cert-type }} certificates..."
+          nix-shell --run 'scripts/predict-new-urls.go --vendor ${{ matrix.vendor-id }} --type ${{ matrix.cert-type }} --out /tmp/${{ matrix.vendor }}-${{ matrix.cert-type }}-available.txt'
+          echo "Verifying all available certificates are in config..."
+          nix-shell --run 'scripts/verify-coverage.go --in /tmp/${{ matrix.vendor }}-${{ matrix.cert-type }}-available.txt --config ${{ matrix.config-file }} --vendor ${{ matrix.vendor-id }}'

--- a/.github/workflows/sanity-check.yaml
+++ b/.github/workflows/sanity-check.yaml
@@ -71,58 +71,6 @@ jobs:
             ./tpmtb bundle download --type ${{ matrix.bundle-type }}
             ./tpmtb bundle verify ./${{ matrix.bundle-file }}
             ./tpmtb bundle validate ./${{ matrix.bundle-file }}
-  vendor-coverage:
-    name: Verify ${{ matrix.vendor }} ${{ matrix.cert-type }} Certificates Coverage
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        vendor: [ifx, stm]
-        cert-type: [root, intermediate]
-        include:
-          - vendor: ifx
-            vendor-id: IFX
-            cert-type: root
-            config-file: .tpm-roots.yaml
-          - vendor: ifx
-            vendor-id: IFX
-            cert-type: intermediate
-            config-file: .tpm-intermediates.yaml
-          - vendor: nsg
-            vendor-id: NSG
-            cert-type: root
-            config-file: .tpm-roots.yaml
-          - vendor: nsg
-            vendor-id: NSG
-            cert-type: intermediate
-            config-file: .tpm-intermediates.yaml
-          - vendor: stm
-            vendor-id: STM
-            cert-type: root
-            config-file: .tpm-roots.yaml
-          - vendor: stm
-            vendor-id: STM
-            cert-type: intermediate
-            config-file: .tpm-intermediates.yaml
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          persist-credentials: false
-      - uses: cachix/install-nix-action@0b0e072294b088b73964f1d72dfdac0951439dbd # v31.8.4
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check ${{ matrix.vendor }} ${{ matrix.cert-type }} coverage
-        run: |
-          echo "Renaming Go scripts..."
-          mv scripts/predict-new-urls.gos scripts/predict-new-urls.go
-          mv scripts/verify-coverage.gos scripts/verify-coverage.go
-          echo "Predicting available ${{ matrix.vendor }} ${{ matrix.cert-type }} certificates..."
-          nix-shell --run 'scripts/predict-new-urls.go --vendor ${{ matrix.vendor-id }} --type ${{ matrix.cert-type }} --out /tmp/${{ matrix.vendor }}-${{ matrix.cert-type }}-available.txt'
-          echo "Verifying all available certificates are in config..."
-          nix-shell --run 'scripts/verify-coverage.go --in /tmp/${{ matrix.vendor }}-${{ matrix.cert-type }}-available.txt --config ${{ matrix.config-file }} --vendor ${{ matrix.vendor-id }}'
   integration-tests:
     name: Run Integration Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Note: this commit migrate cert autodiscovery in a dedicated job to avoid run it during a PR. In addition, the job is now non blocking.