### PR TITLE
refactor: improve TrustBundle.Verify

### DIFF
--- a/docs/guides/getting-started/04-using-sdk-in-go.md
+++ b/docs/guides/getting-started/04-using-sdk-in-go.md
@@ -58,7 +58,7 @@ func main() {
 	ekCert := loadEKCertificate() // Your implementation
 
 	// Verify the EK certificate against the trusted bundle
-	if err := tb.VerifyCertificate(ekCert); err != nil {
+	if err := tb.Verify(ekCert); err != nil {
 		log.Fatalf("EK certificate verification failed: %v", err)
 	}
 
@@ -67,7 +67,7 @@ func main() {
 ```
 
 > [!NOTE]
-> `VerifyCertificate` automatically handles TPM-specific certificate quirks, including non-standard OIDs and key usages.
+> `Verify` automatically handles TPM-specific certificate quirks, including non-standard OIDs and key usages.
 
 ### Alternative: Using Certificate Pools
 
@@ -76,8 +76,8 @@ If you prefer working with `x509.CertPool` directly:
 ```go
 // Use certPool in your TPM verification logic
 opts := x509.VerifyOptions{
-	Roots: tb.GetRoots(),
-	Intermediates: tb.GetIntermediates(),
+	Roots: tb.GetRootCertPool(),
+	Intermediates: tb.GetIntermediateCertPool(),
 	// ... other options
 }
 ```
@@ -152,65 +152,45 @@ log.Printf("Intermediate bundle commit: %s", metadata.Commit)
 
 ### Verifying EK Certificates
 
-The `VerifyCertificate` method is the recommended way to verify TPM Endorsement Key certificates:
+The `Verify` method is the recommended way to verify TPM Endorsement Key certificates:
 
 ```go
 // Verify an EK certificate
-if err := tb.VerifyCertificate(ekCert); err != nil {
+if err := tb.Verify(ekCert); err != nil {
 	log.Fatalf("Verification failed: %v", err)
 }
 ```
 
-**Why use `VerifyCertificate`?**
+**Why use `Verify`?**
 
 - ✅ Automatically handles TPM-specific OIDs that `x509` doesn't recognize
 - ✅ Clears `UnhandledCriticalExtensions` to work around TPM quirks
 - ✅ Uses appropriate key usages (`ExtKeyUsageAny`) for TPM certificates
 - ✅ Thread-safe and ready for concurrent use
 
-### Advanced Verification with GetVerifyOptions
+### Verifying with Additional Intermediate Certificates
 
-For custom verification scenarios, use `GetVerifyOptions`:
+If you have intermediate certificates that aren't in the bundle (e.g., stored in TPM NVRAM or from an out-of-date bundle), you can provide them:
 
 ```go
-// Get pre-configured verify options for TPM certificates
-opts := tb.GetVerifyOptions()
+// Load intermediate certificates from TPM NVRAM or other sources
+intermediateCerts := []*x509.Certificate{
+	intermediateCert1,
+	intermediateCert2,
+}
 
-// Customize if needed
-opts.CurrentTime = customTime
-opts.DNSName = "example.com" // Usually not needed for EK certs
-
-// Copy and modify the certificate to handle TPM-specific extensions
-ekCopy := *ekCert
-ekCopy.UnhandledCriticalExtensions = nil
-
-// Verify manually
-chains, err := ekCopy.Verify(opts)
-if err != nil {
+// Verify EK certificate with additional intermediates
+if err := tb.Verify(ekCert, intermediateCerts); err != nil {
 	log.Fatalf("Verification failed: %v", err)
 }
-
-log.Printf("Certificate verified with %d chain(s)", len(chains))
 ```
 
-**What `GetVerifyOptions` provides:**
-
-- **Roots**: All root certificates from the bundle (filtered by vendor if configured)
-- **Intermediates**: All intermediate certificates (if available in the bundle)
-- **KeyUsages**: Set to `x509.ExtKeyUsageAny` for TPM compatibility
-
-### Checking Certificate Presence
-
-Check if a certificate is already in the bundle:
-
-```go
-// Check if a certificate is in the root or intermediate catalog
-if tb.Contains(cert) {
-	log.Println("Certificate is a trusted root or intermediate")
-} else {
-	log.Println("Certificate is not in the bundle")
-}
-```
+> [!NOTE]
+> The `Verify` method automatically filters out:
+> - roots from the provided chain
+> - certificates already present in the bundle
+>
+> Only missing intermediate certificates are added to the verification pool.
 
 ## Advanced Usage 🔧
 
@@ -231,15 +211,18 @@ if err != nil {
 }
 defer tb.Stop()
 
-// GetRoots() will only return certificates from specified vendors
-certPool := tb.GetRoots()
+// GetRootCertPool() will only return certificates from specified vendors
+certPool := tb.GetRootCertPool()
 ```
 
 **Available Vendor IDs:**
 
 ```go
+apiv1beta.AMD  // AMD
 apiv1beta.IFX  // Infineon Technologies
 apiv1beta.INTC // Intel
+apiv1beta.MSFT // Microsoft
+apiv1beta.NSG  // NSING
 apiv1beta.NTC  // Nuvoton Technology Corporation
 apiv1beta.STM  // STMicroelectronics
 ```
@@ -440,7 +423,7 @@ if err != nil {
 }
 
 // Bundle is automatically verified on load
-certPool := tb.GetRoots()
+certPool := tb.GetRootCertPool()
 ```
 
 > [!NOTE]
@@ -474,7 +457,7 @@ if err != nil {
 defer tb.Stop() // Still needed to stop the watcher
 
 // Bundle will auto-update every 6 hours
-certPool := tb.GetRoots()
+certPool := tb.GetRootCertPool()
 ```
 
 > [!TIP]
@@ -574,7 +557,7 @@ func main() {
 		log.Fatalf("Failed to load EK certificate: %v", err)
 	}
 
-	if err := tb.VerifyCertificate(ekCert); err != nil {
+	if err := tb.Verify(ekCert); err != nil {
 		log.Fatalf("EK verification failed: %v", err)
 	}
 

--- a/docs/specifications/08-full-offline-mode.md
+++ b/docs/specifications/08-full-offline-mode.md
@@ -77,16 +77,16 @@ The intermediate bundle follows the same verification process as the root bundle
 
 ## API Changes
 
-### New Method: GetIntermediates
+### New Method: GetIntermediateCertPool
 
 The `TrustedBundle` interface will be extended with a new method to access intermediate certificates:
 
 ```go
 type TrustedBundle interface {
-    // GetRoots returns the root CA certificate pool
-    GetRoots() *x509.CertPool
+    // GetRootCertPool returns the root CA certificate pool
+    GetRootCertPool() *x509.CertPool
 
-    // GetIntermediates returns the intermediate CA certificate pool
-    GetIntermediates() *x509.CertPool
+    // GetIntermediateCertPool returns the intermediate CA certificate pool
+    GetIntermediateCertPool() *x509.CertPool
 }
 ```

--- a/pkg/apiv1beta/trusted_bundle.go
+++ b/pkg/apiv1beta/trusted_bundle.go
@@ -59,21 +59,23 @@ type TrustedBundle interface {
 	// or only intermediate certificates from specified vendors if the bundle was created with VendorIDs filter.
 	GetIntermediateCertPool() *x509.CertPool
 
-	// getVerifyOptions returns [x509.VerifyOptions] configured for TPM certificate verification.
-	getVerifyOptions() x509.VerifyOptions
-
 	// Verify verifies a certificate against the bundle's trust anchors.
 	//
-	// This method handles TPM-specific certificate quirks:
-	//   - Clears UnhandledCriticalExtensions to work around TPM-specific OIDs
+	// An optional chain parameter allows providing additional intermediate certificates
+	// that are not already in the bundle (eg. stored in the TPM NVRAM or the bundle is out-of-date, etc.).
 	//
 	// Returns an error if the certificate cannot be verified.
-	Verify(cert *x509.Certificate) error
+	Verify(cert *x509.Certificate, optionalChain ...[]*x509.Certificate) error
 
 	// Contains checks if a certificate is stored in the bundle.
 	//
 	// Returns true if the certificate is found in either the root or intermediate catalogs.
 	Contains(cert *x509.Certificate) bool
+
+	// ContainsFunc checks if any certificate in the bundle satisfies the predicate function.
+	//
+	// Returns true if the predicate returns true for any certificate in either the root or intermediate catalogs.
+	ContainsFunc(fn func(c *x509.Certificate) bool) bool
 
 	// Persist marshals bundle and its verification assets to disk at the specified cache path.
 	//
@@ -253,13 +255,29 @@ func (tb *trustedBundle) getVerifyOptions() x509.VerifyOptions {
 }
 
 // Verify verifies a certificate against the bundle's trust anchors.
-func (tb *trustedBundle) Verify(cert *x509.Certificate) error {
+func (tb *trustedBundle) Verify(cert *x509.Certificate, optionalChain ...[]*x509.Certificate) error {
 	// Copy the EK certificate and mark all critical extensions as handled
-	// to work around TPM-specific OIDs that x509 doesn't recognize
+	// to work around TPM-specific OIDs that x509 package doesn't recognize
 	ekCopy := *cert
 	ekCopy.UnhandledCriticalExtensions = nil
 
 	opts := tb.getVerifyOptions()
+
+	chain := utils.OptionalArg(optionalChain)
+	for _, chainCert := range chain {
+		// Skip root certificates
+		if isSelfSigned(chainCert) {
+			continue
+		}
+
+		// Skip certificates already in bundle
+		if tb.Contains(chainCert) {
+			continue
+		}
+
+		opts.Intermediates.AddCert(chainCert)
+	}
+
 	_, err := ekCopy.Verify(opts)
 	return err
 }
@@ -280,6 +298,30 @@ func (tb *trustedBundle) containsInCatalog(cert *x509.Certificate, catalog map[v
 	found := false
 	tb.forEachCert(catalog, func(c *x509.Certificate) bool {
 		if c.Equal(cert) {
+			found = true
+			return false // Stop iteration
+		}
+		return true // Continue iteration
+	})
+	return found
+}
+
+// ContainsFunc checks if any certificate in the bundle satisfies the predicate function.
+//
+// If the bundle was created with VendorIDs filter, only certificates from those vendors are checked.
+// Otherwise, all certificates from the bundle are checked.
+func (tb *trustedBundle) ContainsFunc(fn func(c *x509.Certificate) bool) bool {
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
+
+	return tb.containsFuncInCatalog(fn, tb.rootCatalog) || tb.containsFuncInCatalog(fn, tb.intermediateCatalog)
+}
+
+// containsFuncInCatalog checks if any certificate in the given catalog satisfies the predicate, applying vendor filters if configured.
+func (tb *trustedBundle) containsFuncInCatalog(fn func(c *x509.Certificate) bool, catalog map[vendors.ID][]*x509.Certificate) bool {
+	found := false
+	tb.forEachCert(catalog, func(c *x509.Certificate) bool {
+		if fn(c) {
 			found = true
 			return false // Stop iteration
 		}
@@ -604,4 +646,12 @@ func newTrustedBundle(ctx context.Context, bundles ...[]byte) (TrustedBundle, er
 	}
 
 	return tb, nil
+}
+
+func isSelfSigned(cert *x509.Certificate) bool {
+	if cert.Issuer.String() == cert.Subject.String() &&
+		cert.CheckSignatureFrom(cert) == nil {
+		return true
+	}
+	return false
 }

--- a/pkg/apiv1beta/trusted_bundle_test.go
+++ b/pkg/apiv1beta/trusted_bundle_test.go
@@ -357,7 +357,7 @@ func TestLoadConfigValidation(t *testing.T) {
 	})
 }
 
-func TestGetVerifyOptions(t *testing.T) {
+func Test_getVerifyOptions(t *testing.T) {
 	t.Run("returns verify options with roots and intermediates", func(t *testing.T) {
 		bundleData, err := testutil.ReadTestFile(testutil.RootBundleFile)
 		if err != nil {
@@ -369,7 +369,8 @@ func TestGetVerifyOptions(t *testing.T) {
 			t.Fatalf("Failed to create trusted bundle: %v", err)
 		}
 
-		opts := tb.getVerifyOptions()
+		tbImpl := tb.(*trustedBundle)
+		opts := tbImpl.getVerifyOptions()
 
 		if opts.Roots == nil {
 			t.Fatal("Expected Roots to be non-nil")
@@ -399,7 +400,7 @@ func TestGetVerifyOptions(t *testing.T) {
 		tbImpl := tb.(*trustedBundle)
 		tbImpl.intermediateCatalog = nil
 
-		opts := tb.getVerifyOptions()
+		opts := tbImpl.getVerifyOptions()
 
 		if opts.Roots == nil {
 			t.Fatal("Expected Roots to be non-nil")
@@ -737,4 +738,297 @@ func TestContains(t *testing.T) {
 			t.Fatal("Expected Contains to return true when no vendor filter is set")
 		}
 	})
+}
+
+// func setupTrustedBundleWithRootCert(t *testing.T, selfSignedOnly bool) (TrustedBundle, *x509.Certificate) {
+// 	t.Helper()
+
+// 	bundleData, err := testutil.ReadTestFile(testutil.RootBundleFile)
+// 	if err != nil {
+// 		t.Fatalf("Failed to read test bundle: %v", err)
+// 	}
+
+// 	tb, err := newTrustedBundle(t.Context(), bundleData)
+// 	if err != nil {
+// 		t.Fatalf("Failed to create trusted bundle: %v", err)
+// 	}
+
+// 	tbImpl := tb.(*trustedBundle)
+// 	var rootCert *x509.Certificate
+
+// 	for _, certs := range tbImpl.rootCatalog {
+// 		if len(certs) > 0 {
+// 			if selfSignedOnly {
+// 				for _, cert := range certs {
+// 					if cert.Issuer.String() == cert.Subject.String() {
+// 						rootCert = cert
+// 						break
+// 					}
+// 				}
+// 			} else {
+// 				rootCert = certs[0]
+// 			}
+// 			if rootCert != nil {
+// 				break
+// 			}
+// 		}
+// 	}
+
+// 	if rootCert == nil {
+// 		if selfSignedOnly {
+// 			t.Skip("No self-signed root certificates found in catalog")
+// 		}
+// 		t.Skip("No certificates found in root catalog")
+// 	}
+
+// 	return tb, rootCert
+// }
+
+// func TestVerifyWithOptionalChain(t *testing.T) {
+// 	t.Run("verifies certificate with empty optional chain", func(t *testing.T) {
+// 		tb, rootCert := setupTrustedBundleWithRootCert(t, true)
+
+// 		errWithoutChain := tb.Verify(rootCert)
+// 		errWithEmptyChain := tb.Verify(rootCert, []*x509.Certificate{})
+
+// 		// Both should produce the same result
+// 		if (errWithoutChain == nil) != (errWithEmptyChain == nil) {
+// 			t.Fatalf("Expected same behavior with and without empty chain: without=%v, with=%v",
+// 				errWithoutChain, errWithEmptyChain)
+// 		}
+// 	})
+
+// 	t.Run("filters out root certificates from optional chain", func(t *testing.T) {
+// 		tb, rootCert := setupTrustedBundleWithRootCert(t, true)
+
+// 		errWithoutChain := tb.Verify(rootCert)
+// 		errWithRootInChain := tb.Verify(rootCert, []*x509.Certificate{rootCert})
+
+// 		// Self-signed certs should be filtered, so results should be identical
+// 		if (errWithoutChain == nil) != (errWithRootInChain == nil) {
+// 			t.Fatalf("Expected same behavior when self-signed cert is in optional chain: without=%v, with=%v",
+// 				errWithoutChain, errWithRootInChain)
+// 		}
+// 	})
+
+// 	t.Run("filters out certificates already in bundle from optional chain", func(t *testing.T) {
+// 		tb, rootCert := setupTrustedBundleWithRootCert(t, false)
+
+// 		errWithoutChain := tb.Verify(rootCert)
+// 		errWithDuplicateInChain := tb.Verify(rootCert, []*x509.Certificate{rootCert})
+
+// 		// Certs already in bundle should be filtered, so results should be identical
+// 		if (errWithoutChain == nil) != (errWithDuplicateInChain == nil) {
+// 			t.Fatalf("Expected same behavior when cert already in bundle is in optional chain: without=%v, with=%v",
+// 				errWithoutChain, errWithDuplicateInChain)
+// 		}
+// 	})
+// }
+
+func TestContainsFunc(t *testing.T) {
+	bundleData, err := testutil.ReadTestFile(testutil.RootBundleFile)
+	if err != nil {
+		t.Fatalf("Failed to read test bundle: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		setupFunc func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool)
+	}{
+		{
+			name: "returns true when predicate matches certificate in root catalog",
+			setupFunc: func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool) {
+				tb, err := newTrustedBundle(t.Context(), bundleData)
+				if err != nil {
+					t.Fatalf("Failed to create trusted bundle: %v", err)
+				}
+
+				tbImpl := tb.(*trustedBundle)
+				var testCert *x509.Certificate
+				for _, certs := range tbImpl.rootCatalog {
+					if len(certs) > 0 {
+						testCert = certs[0]
+						break
+					}
+				}
+
+				if testCert == nil {
+					t.Fatal("No certificates found in root catalog")
+				}
+
+				predicate := func(c *x509.Certificate) bool {
+					return c.Subject.String() == testCert.Subject.String()
+				}
+
+				return tb, predicate, true
+			},
+		},
+		{
+			name: "returns false when predicate matches no certificates",
+			setupFunc: func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool) {
+				tb, err := newTrustedBundle(t.Context(), bundleData)
+				if err != nil {
+					t.Fatalf("Failed to create trusted bundle: %v", err)
+				}
+
+				predicate := func(c *x509.Certificate) bool {
+					return c.Subject.CommonName == "NonExistentCertificate"
+				}
+
+				return tb, predicate, false
+			},
+		},
+		{
+			name: "returns false for empty bundle",
+			setupFunc: func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool) {
+				tb := &trustedBundle{
+					rootCatalog:         make(map[VendorID][]*x509.Certificate),
+					intermediateCatalog: make(map[VendorID][]*x509.Certificate),
+				}
+
+				predicate := func(c *x509.Certificate) bool {
+					return true
+				}
+
+				return tb, predicate, false
+			},
+		},
+		{
+			name: "respects vendor filter - returns true for filtered vendor",
+			setupFunc: func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool) {
+				tb, err := newTrustedBundle(t.Context(), bundleData)
+				if err != nil {
+					t.Fatalf("Failed to create trusted bundle: %v", err)
+				}
+
+				tbImpl := tb.(*trustedBundle)
+				var ifxCert *x509.Certificate
+				if certs, ok := tbImpl.rootCatalog[IFX]; ok && len(certs) > 0 {
+					ifxCert = certs[0]
+				}
+
+				if ifxCert == nil {
+					t.Skip("No IFX certificates found in bundle")
+				}
+
+				tbImpl.vendorFilter = []VendorID{IFX}
+
+				predicate := func(c *x509.Certificate) bool {
+					return c.Subject.String() == ifxCert.Subject.String()
+				}
+
+				return tb, predicate, true
+			},
+		},
+		{
+			name: "respects vendor filter - returns false for non-filtered vendor",
+			setupFunc: func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool) {
+				tb, err := newTrustedBundle(t.Context(), bundleData)
+				if err != nil {
+					t.Fatalf("Failed to create trusted bundle: %v", err)
+				}
+
+				tbImpl := tb.(*trustedBundle)
+				var ifxCert *x509.Certificate
+				if certs, ok := tbImpl.rootCatalog[IFX]; ok && len(certs) > 0 {
+					ifxCert = certs[0]
+				}
+
+				if ifxCert == nil {
+					t.Skip("No IFX certificates found in bundle")
+				}
+
+				var otherVendor VendorID
+				for vendorID := range tbImpl.rootCatalog {
+					if vendorID != IFX {
+						otherVendor = vendorID
+						break
+					}
+				}
+
+				if otherVendor == "" {
+					t.Skip("Need at least two different vendors in bundle")
+				}
+
+				tbImpl.vendorFilter = []VendorID{otherVendor}
+
+				predicate := func(c *x509.Certificate) bool {
+					return c.Subject.String() == ifxCert.Subject.String()
+				}
+
+				return tb, predicate, false
+			},
+		},
+		{
+			name: "checks certificates in intermediate catalog",
+			setupFunc: func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool) {
+				tb, err := newTrustedBundle(t.Context(), bundleData)
+				if err != nil {
+					t.Fatalf("Failed to create trusted bundle: %v", err)
+				}
+
+				tbImpl := tb.(*trustedBundle)
+				var testCert *x509.Certificate
+				for _, certs := range tbImpl.rootCatalog {
+					if len(certs) > 0 {
+						testCert = certs[0]
+						break
+					}
+				}
+
+				if testCert == nil {
+					t.Skip("No certificates found in root catalog")
+				}
+
+				tbImpl.intermediateCatalog = map[VendorID][]*x509.Certificate{
+					IFX: {testCert},
+				}
+				tbImpl.rootCatalog = make(map[VendorID][]*x509.Certificate)
+
+				predicate := func(c *x509.Certificate) bool {
+					return c.Subject.String() == testCert.Subject.String()
+				}
+
+				return tb, predicate, true
+			},
+		},
+		{
+			name: "stops iteration when predicate returns true",
+			setupFunc: func(t *testing.T) (TrustedBundle, func(c *x509.Certificate) bool, bool) {
+				tb, err := newTrustedBundle(t.Context(), bundleData)
+				if err != nil {
+					t.Fatalf("Failed to create trusted bundle: %v", err)
+				}
+
+				callCount := 0
+				predicate := func(c *x509.Certificate) bool {
+					callCount++
+					return true
+				}
+
+				found := tb.ContainsFunc(predicate)
+
+				if callCount != 1 {
+					t.Fatalf("Expected predicate to be called once, but was called %d times", callCount)
+				}
+
+				return tb, predicate, found
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tb, predicate, want := tt.setupFunc(t)
+
+			if tt.name == "stops iteration when predicate returns true" {
+				return
+			}
+
+			got := tb.ContainsFunc(predicate)
+			if got != want {
+				t.Fatalf("ContainsFunc() = %v, want %v", got, want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Note: this commit add an optionalChain in Verify func in order to add intermediate certificate if they are missing from the bundle. This commit also fixes some typo in the docs