### PR TITLE
fix(api): harmonized Persit signature

### DIFF
--- a/cmd/bundle/save/save.go
+++ b/cmd/bundle/save/save.go
@@ -110,7 +110,7 @@ func Run(ctx context.Context, o *Opts) error {
 	if o.LocalCache {
 		targetDir = cache.CacheDir()
 	}
-	if err := resp.Persist(targetDir); err != nil {
+	if err := resp.Persist(ctx, targetDir); err != nil {
 		return fmt.Errorf("failed to persist bundle: %w", err)
 	}
 

--- a/docs/guides/getting-started/04-using-sdk-in-go.md
+++ b/docs/guides/getting-started/04-using-sdk-in-go.md
@@ -384,12 +384,12 @@ if err != nil {
 defer tb.Stop()
 
 // Persist to default location ($HOME/.tpmtb)
-if err := tb.Persist(); err != nil {
+if err := tb.Persist(ctx); err != nil {
 	log.Fatalf("Failed to persist bundle: %v", err)
 }
 
 // Or persist to a custom location
-if err := tb.Persist("/custom/cache/path"); err != nil {
+if err := tb.Persist(ctx, "/custom/cache/path"); err != nil {
 	log.Fatalf("Failed to persist bundle: %v", err)
 }
 ```
@@ -443,7 +443,7 @@ if err != nil {
 	log.Fatal(err)
 }
 
-if err := tb.Persist(); err != nil {
+if err := tb.Persist(ctx); err != nil {
 	log.Fatal(err)
 }
 tb.Stop()

--- a/docs/guides/getting-started/05-offline-mode.md
+++ b/docs/guides/getting-started/05-offline-mode.md
@@ -137,7 +137,7 @@ func main() {
 	}
 
 	// Save all artifacts for offline use
-	if err := resp.Persist("/path/to/cache"); err != nil {
+	if err := resp.Persist(ctx, "/path/to/cache"); err != nil {
 		log.Fatalf("Failed to persist cache: %v", err)
 	}
 
@@ -224,7 +224,7 @@ if err != nil {
 }
 defer tb.Stop()
 
-if err := tb.Persist("/path/to/cache"); err != nil {
+if err := tb.Persist(ctx, "/path/to/cache"); err != nil {
 	log.Fatal(err)
 }
 ```
@@ -247,7 +247,7 @@ if err != nil {
 defer tb.Stop()
 
 // Persist filtered bundle
-if err := tb.Persist("/path/to/cache"); err != nil {
+if err := tb.Persist(ctx, "/path/to/cache"); err != nil {
 	log.Fatal(err)
 }
 

--- a/pkg/apiv1beta/api.go
+++ b/pkg/apiv1beta/api.go
@@ -296,21 +296,18 @@ type SaveResponse struct {
 // Persist writes all assets to the specified output directory.
 //
 // If outputDir is empty, the default cache directory ($HOME/.tpmtb) is used.
-func (sr *SaveResponse) Persist(outputDir string) error {
-	if outputDir == "" {
-		outputDir = cache.CacheDir()
-	}
+func (sr *SaveResponse) Persist(ctx context.Context, optionalOutputDir ...string) error {
+	outputDir := utils.OptionalArgWithDefault(optionalOutputDir, cache.CacheDir())
+	cleanOutputDir := filepath.Clean(outputDir)
 
-	outputDir = filepath.Clean(outputDir)
-
-	if !utils.DirExists(outputDir) {
-		if err := os.MkdirAll(outputDir, 0700); err != nil {
+	if !utils.DirExists(cleanOutputDir) {
+		if err := os.MkdirAll(cleanOutputDir, 0700); err != nil {
 			return fmt.Errorf("failed to create output directory: %w", err)
 		}
 	}
 
 	return persistAllBundleAssets(
-		outputDir,
+		cleanOutputDir,
 		sr.RootBundle,
 		sr.IntermediateBundle,
 		sr.Checksum,
@@ -338,7 +335,7 @@ func (sr *SaveResponse) Persist(outputDir string) error {
 //	}
 //
 //	// Persist to default cache directory ($HOME/.tpmtb)
-//	if err := resp.Persist(); err != nil {
+//	if err := resp.Persist(ctx); err != nil {
 //	    log.Fatal(err)
 //	}
 //

--- a/tests/integration/apiv1beta_test.go
+++ b/tests/integration/apiv1beta_test.go
@@ -891,7 +891,7 @@ func TestSave(t *testing.T) {
 		}
 
 		outputDir := t.TempDir()
-		if err := resp.Persist(outputDir); err != nil {
+		if err := resp.Persist(t.Context(), outputDir); err != nil {
 			t.Fatalf("Persist() error = %v", err)
 		}
 
@@ -945,7 +945,7 @@ func TestSave(t *testing.T) {
 
 		// Persist to cache directory
 		cacheDir := t.TempDir()
-		if err := resp.Persist(cacheDir); err != nil {
+		if err := resp.Persist(t.Context(), cacheDir); err != nil {
 			t.Fatalf("Persist() error = %v", err)
 		}
 


### PR DESCRIPTION
Note: this commit use the same signature for SaveResponse.Persist and TrustBundle.Persist for consistency. The function takes two args: context + optional cache dir path