### PR TITLE
refactor(cli): add Check method in Opts

### DIFF
--- a/cmd/bundle/download/download.go
+++ b/cmd/bundle/download/download.go
@@ -24,6 +24,24 @@ type Opts struct {
 	CacheDir   string
 }
 
+// Check validates the download command options.
+func (o *Opts) Check() error {
+	if o.OutputDir != "-" && !fsutil.DirExists(o.OutputDir) {
+		return fmt.Errorf("output directory %s does not exist", o.OutputDir)
+	}
+
+	bundleType := bundle.BundleType(o.Type)
+	if err := bundleType.Validate(); err != nil {
+		return err
+	}
+
+	if o.OutputDir == "-" && o.Type == "" {
+		return fmt.Errorf("when using stdout (--output-dir -), you must specify --type (root or intermediate)")
+	}
+
+	return nil
+}
+
 // NewCommand creates the download command.
 func NewCommand() *cobra.Command {
 	opts := &Opts{}
@@ -86,19 +104,8 @@ type bundleInfo struct {
 
 // Run executes the download command.
 func Run(ctx context.Context, o *Opts) error {
-	if o.OutputDir != "-" && !fsutil.DirExists(o.OutputDir) {
-		return fmt.Errorf("output directory %s does not exist", o.OutputDir)
-	}
-
-	// Validate and parse bundle type
-	bundleType := bundle.BundleType(o.Type)
-	if err := bundleType.Validate(); err != nil {
+	if err := o.Check(); err != nil {
 		return err
-	}
-
-	// Validate stdout usage
-	if o.OutputDir == "-" && bundleType == bundle.TypeUnspecified {
-		return fmt.Errorf("when using stdout (--output-dir -), you must specify --type (root or intermediate)")
 	}
 
 	if o.Date == "" {
@@ -128,7 +135,7 @@ func Run(ctx context.Context, o *Opts) error {
 	}
 
 	var bundleInfos []bundleInfo
-	switch bundleType {
+	switch bundle.BundleType(o.Type) {
 	case bundle.TypeRoot:
 		bundleInfos = []bundleInfo{
 			{

--- a/cmd/bundle/generate/generate.go
+++ b/cmd/bundle/generate/generate.go
@@ -23,6 +23,31 @@ type Opts struct {
 	Type       string
 }
 
+// Check validates the generate command options.
+func (o *Opts) Check() error {
+	if o.Workers > concurrency.MaxWorkers {
+		return fmt.Errorf("concurrency value %d exceeds maximum allowed (%d)", o.Workers, concurrency.MaxWorkers)
+	}
+
+	if (o.Date != "" && o.Commit == "") || (o.Date == "" && o.Commit != "") {
+		return fmt.Errorf("both --date and --commit flags must be provided together")
+	}
+
+	if o.Date != "" {
+		if err := bundle.ValidateDate(o.Date); err != nil {
+			return fmt.Errorf("invalid --date flag: %w", err)
+		}
+	}
+
+	if o.Commit != "" {
+		if err := bundle.ValidateCommit(o.Commit); err != nil {
+			return fmt.Errorf("invalid --commit flag: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // NewCommand creates the generate command.
 func NewCommand() *cobra.Command {
 	o := &Opts{}
@@ -70,13 +95,13 @@ By default, output is written to stdout. Use --output to write to a file instead
 }
 
 func Run(ctx context.Context, o *Opts) error {
+	if err := o.Check(); err != nil {
+		return err
+	}
+
 	cfg, err := config.LoadConfig(o.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
-	}
-
-	if o.Workers > concurrency.MaxWorkers {
-		return fmt.Errorf("concurrency value %d exceeds maximum allowed (%d)", o.Workers, concurrency.MaxWorkers)
 	}
 
 	bundleType, err := resolveBundleType(o.Type, o.ConfigPath)
@@ -84,19 +109,9 @@ func Run(ctx context.Context, o *Opts) error {
 		return fmt.Errorf("failed to resolve bundle type: %w", err)
 	}
 
-	if (o.Date != "" && o.Commit == "") || (o.Date == "" && o.Commit != "") {
-		return fmt.Errorf("both --date and --commit flags must be provided together")
-	}
-
 	var bundleDate, bundleCommit string
 
 	if o.Date != "" && o.Commit != "" {
-		if err := bundle.ValidateDate(o.Date); err != nil {
-			return fmt.Errorf("invalid --date flag: %w", err)
-		}
-		if err := bundle.ValidateCommit(o.Commit); err != nil {
-			return fmt.Errorf("invalid --commit flag: %w", err)
-		}
 		bundleDate = o.Date
 		bundleCommit = o.Commit
 	} else {

--- a/cmd/bundle/save/save.go
+++ b/cmd/bundle/save/save.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	goutils "github.com/loicsikidi/go-utils"
 	"github.com/loicsikidi/go-utils/system/fsutil"
 	"github.com/loicsikidi/tpm-ca-certificates/internal/cache"
 	"github.com/loicsikidi/tpm-ca-certificates/internal/cli"
@@ -19,6 +20,27 @@ type Opts struct {
 	OutputDir  string
 	Force      bool
 	LocalCache bool
+}
+
+func (o *Opts) Check() error {
+	for _, vid := range o.VendorIDs {
+		vendorID := apiv1beta.VendorID(vid)
+		if err := vendorID.Validate(); err != nil {
+			return fmt.Errorf("invalid vendor ID %q: %w", vid, err)
+		}
+	}
+
+	if !o.LocalCache && !fsutil.DirExists(o.OutputDir) {
+		return fmt.Errorf("output directory %s does not exist", o.OutputDir)
+	}
+
+	if !o.Force && !o.LocalCache {
+		if err := checkExistingFiles(o.OutputDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // NewCommand creates the save command.
@@ -69,23 +91,8 @@ verification without network access.`,
 
 // Run executes the save command with the given options.
 func Run(ctx context.Context, o *Opts) error {
-	if !fsutil.DirExists(o.OutputDir) {
-		return fmt.Errorf("output directory %s does not exist", o.OutputDir)
-	}
-
-	var parsedVendorIDs []apiv1beta.VendorID
-	for _, vid := range o.VendorIDs {
-		vendorID := apiv1beta.VendorID(vid)
-		if err := vendorID.Validate(); err != nil {
-			return fmt.Errorf("invalid vendor ID %q: %w", vid, err)
-		}
-		parsedVendorIDs = append(parsedVendorIDs, vendorID)
-	}
-
-	if !o.Force && !o.LocalCache {
-		if err := checkExistingFiles(o.OutputDir); err != nil {
-			return err
-		}
+	if err := o.Check(); err != nil {
+		return err
 	}
 
 	if o.Date == "" {
@@ -95,8 +102,10 @@ func Run(ctx context.Context, o *Opts) error {
 	}
 
 	cfg := apiv1beta.SaveConfig{
-		Date:      o.Date,
-		VendorIDs: parsedVendorIDs,
+		Date: o.Date,
+		VendorIDs: goutils.Map(o.VendorIDs, func(id string) apiv1beta.VendorID {
+			return apiv1beta.VendorID(id)
+		}),
 	}
 
 	resp, err := apiv1beta.SaveTrustedBundle(ctx, cfg)

--- a/cmd/bundle/verify/verify.go
+++ b/cmd/bundle/verify/verify.go
@@ -24,6 +24,14 @@ type Opts struct {
 	Offline            bool
 }
 
+// Check validates the verify command options.
+func (o *Opts) Check() error {
+	if o.CacheDir != "" && !fsutil.DirExists(o.CacheDir) {
+		return fmt.Errorf("cache directory does not exist: %s", o.CacheDir)
+	}
+	return nil
+}
+
 // NewCommand creates the verify command.
 //
 // The verify command validates the authenticity and integrity of a TPM trust bundle
@@ -82,11 +90,11 @@ Both verifications must succeed for the bundle to be considered valid.`,
 }
 
 func run(cmd *cobra.Command, args []string, o *Opts) error {
-	bundlePath := args[0]
-
-	if o.CacheDir != "" && !fsutil.DirExists(o.CacheDir) {
-		return fmt.Errorf("cache directory does not exist: %s", o.CacheDir)
+	if err := o.Check(); err != nil {
+		return err
 	}
+
+	bundlePath := args[0]
 
 	var bundleDir, bundleFilename string
 	if bundlePath == "-" {

--- a/cmd/config/sanity/sanity.go
+++ b/cmd/config/sanity/sanity.go
@@ -17,16 +17,30 @@ const (
 )
 
 var (
-	configPath    string
-	quiet         bool
-	workers       int
-	threshold     int
 	osExit        = os.Exit // Allow mocking in tests
 	checkerGetter = sanity.NewChecker
 )
 
+// Opts represents the configuration options for the sanity command.
+type Opts struct {
+	ConfigPath string
+	Quiet      bool
+	Workers    int
+	Threshold  int
+}
+
+// Check validates the sanity command options.
+func (o *Opts) Check() error {
+	if o.Workers > concurrency.MaxWorkers {
+		return fmt.Errorf("concurrency value %d exceeds maximum allowed (%d)", o.Workers, concurrency.MaxWorkers)
+	}
+	return nil
+}
+
 // NewCommand creates the sanity command.
 func NewCommand() *cobra.Command {
+	o := &Opts{}
+
 	cmd := &cobra.Command{
 		Use:   "sanity",
 		Short: "perform sanity checks on the configuration file",
@@ -51,45 +65,47 @@ Shows up to 10 validation errors and 10 expiration warnings.`,
   # Quiet mode (only return exit code)
   tpmtb config sanity --quiet`,
 		SilenceUsage: true,
-		RunE:         run,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, args, o)
+		},
 	}
 
-	cmd.Flags().StringVarP(&configPath, "config", "c", ".tpm-roots.yaml",
+	cmd.Flags().StringVarP(&o.ConfigPath, "config", "c", ".tpm-roots.yaml",
 		"Path to TPM roots configuration file")
-	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false,
+	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", false,
 		"Suppress output, only return exit code")
-	cmd.Flags().IntVarP(&workers, "workers", "j", 0,
+	cmd.Flags().IntVarP(&o.Workers, "workers", "j", 0,
 		fmt.Sprintf("Number of workers to use (0=auto-detect, max=%d)", concurrency.MaxWorkers))
-	cmd.Flags().IntVarP(&threshold, "threshold", "t", defaultThreshold,
+	cmd.Flags().IntVarP(&o.Threshold, "threshold", "t", defaultThreshold,
 		"Days threshold for expiration warnings (default: 365 days)")
 
 	return cmd
 }
 
-func run(cmd *cobra.Command, args []string) error {
-	cfg, err := config.LoadConfig(configPath)
+func run(_ *cobra.Command, _ []string, o *Opts) error {
+	if err := o.Check(); err != nil {
+		return err
+	}
+
+	cfg, err := config.LoadConfig(o.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	if workers > concurrency.MaxWorkers {
-		return fmt.Errorf("concurrency value %d exceeds maximum allowed (%d)", workers, concurrency.MaxWorkers)
-	}
-
 	checker := checkerGetter()
-	result, err := checker.Check(cfg, workers, threshold)
+	result, err := checker.Check(cfg, o.Workers, o.Threshold)
 	if err != nil {
 		return fmt.Errorf("sanity check failed: %w", err)
 	}
 
 	if !result.HasIssues() {
-		if !quiet {
+		if !o.Quiet {
 			cli.DisplaySuccess("✅ All certificates passed sanity checks.")
 		}
 		return nil
 	}
 
-	if !quiet {
+	if !o.Quiet {
 		displayResults(result)
 	}
 

--- a/cmd/config/sanity/sanity_test.go
+++ b/cmd/config/sanity/sanity_test.go
@@ -108,7 +108,7 @@ func TestSanityCommand(t *testing.T) {
 
 			// Create temporary config file
 			tmpDir := t.TempDir()
-			configPath = filepath.Join(tmpDir, ".tpm-roots.yaml")
+			configPath := filepath.Join(tmpDir, ".tpm-roots.yaml")
 
 			configContent := `---
 version: "test"
@@ -126,10 +126,13 @@ vendors:
 				t.Fatalf("failed to create test config: %v", err)
 			}
 
-			// Set flags
-			quiet = tt.quiet
-			threshold = tt.threshold
-			workers = 1
+			// Create opts
+			opts := &Opts{
+				ConfigPath: configPath,
+				Quiet:      tt.quiet,
+				Threshold:  tt.threshold,
+				Workers:    1,
+			}
 
 			// Mock checker with server's HTTP client
 			checkerGetter = func() *sanity.Checker {
@@ -154,7 +157,7 @@ vendors:
 			}
 
 			// Run the command
-			err := run(nil, nil)
+			err := run(nil, nil, opts)
 
 			// Restore stdout/stderr
 			wOut.Close()
@@ -205,12 +208,14 @@ vendors:
 }
 
 func TestSanityCommand_ConfigNotFound(t *testing.T) {
-	configPath = "/tmp/nonexistent-config.yaml"
-	quiet = false
-	threshold = 90
-	workers = 1
+	opts := &Opts{
+		ConfigPath: "/tmp/nonexistent-config.yaml",
+		Quiet:      false,
+		Threshold:  90,
+		Workers:    1,
+	}
 
-	err := run(nil, nil)
+	err := run(nil, nil, opts)
 	if err == nil {
 		t.Error("expected error for missing config file")
 	}
@@ -221,7 +226,7 @@ func TestSanityCommand_ConfigNotFound(t *testing.T) {
 
 func TestSanityCommand_InvalidWorkers(t *testing.T) {
 	tmpDir := t.TempDir()
-	configPath = filepath.Join(tmpDir, ".tpm-roots.yaml")
+	configPath := filepath.Join(tmpDir, ".tpm-roots.yaml")
 
 	configContent := `---
 version: "test"
@@ -239,11 +244,14 @@ vendors:
 		t.Fatalf("failed to create test config: %v", err)
 	}
 
-	quiet = false
-	threshold = 90
-	workers = 1000 // Exceeds MaxWorkers
+	opts := &Opts{
+		ConfigPath: configPath,
+		Quiet:      false,
+		Threshold:  90,
+		Workers:    1000, // Exceeds MaxWorkers
+	}
 
-	err := run(nil, nil)
+	err := run(nil, nil, opts)
 	if err == nil {
 		t.Error("expected error for invalid workers count")
 	}

--- a/cmd/config/sanity/sanity_test.go
+++ b/cmd/config/sanity/sanity_test.go
@@ -209,7 +209,7 @@ vendors:
 
 func TestSanityCommand_ConfigNotFound(t *testing.T) {
 	opts := &Opts{
-		ConfigPath: "/tmp/nonexistent-config.yaml",
+		ConfigPath: filepath.Join(t.TempDir(), "nonexistent-config.yaml"),
 		Quiet:      false,
 		Threshold:  90,
 		Workers:    1,

--- a/pkg/apiv1beta/trusted_bundle_test.go
+++ b/pkg/apiv1beta/trusted_bundle_test.go
@@ -121,12 +121,18 @@ func TestPersist(t *testing.T) {
 		}
 
 		// Verify files were overwritten
-		bundleContent, _ := fsutil.ReadFile(bundlePath)
+		bundleContent, err := fsutil.ReadFile(bundlePath)
+		if err != nil {
+			t.Fatalf("Failed to read bundle file: %v", err)
+		}
 		if string(bundleContent) == "old bundle" {
 			t.Fatal("Bundle file was not overwritten")
 		}
 
-		configContent, _ := fsutil.ReadFile(configPath)
+		configContent, err := fsutil.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read config file: %v", err)
+		}
 		if string(configContent) == "old config" {
 			t.Fatal("Config file was not overwritten")
 		}


### PR DESCRIPTION
Note: this commit adds Check method in Opts in order to centralize input validation at a single place. Overall, this change decreases the complexity of Run functions and improve clarity.

In addition, this commit improve trusted_bundle_test.go thanks to more assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized option validation across CLI commands (bundle download, generate, save, verify, and config sanity) for consistent behavior
  * Sanity command moved to per-command options structure and enforces worker limits before loading config
  * Save command only validates output directory when not using local cache

* **Tests**
  * Updated tests to align with refactored validation and to assert persisted files are readable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->