### PR TITLE
fix: forget to migrate placeholder in config.go

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,9 +20,9 @@ const (
 	SHA512 = "sha512"
 )
 
-const repoPlaceholder = "{repo}"
+const localPlaceholder = "{local}"
 
-var ErrMissingRepoPlaceholder = errors.New("invalid uri: missing repo placeholder in file URI")
+var ErrMissingLocalPlaceholder = errors.New("invalid uri: missing local placeholder in file URI")
 
 // TPMRootsConfig represents a configuration file listing TPM vendors certificates.
 type TPMRootsConfig struct {
@@ -71,7 +71,7 @@ func (c *TPMRootsConfig) transformFileURIPlaceholders(sourceDir string, isMarsha
 				}
 
 				var p string
-				pattern := "/" + repoPlaceholder
+				pattern := "/" + localPlaceholder
 				if isMarshal {
 					p = strings.ReplaceAll(u.Path, absSourceDir, pattern)
 				} else {
@@ -87,14 +87,14 @@ func (c *TPMRootsConfig) transformFileURIPlaceholders(sourceDir string, isMarsha
 
 // ResolveFileURLPlaceholders replaces placeholders in file URLs with actual paths.
 //
-// Note: {repo} is replaced with the absolute path of the source directory.
+// Note: {local} is replaced with the absolute path of the source directory.
 func (c *TPMRootsConfig) resolveFileURIPlaceholders(sourceDir string) error {
 	return c.transformFileURIPlaceholders(sourceDir /* isMarshal= */, false)
 }
 
 // createFileURIPlaceholders replaces actual paths in file URIs with placeholders.
 //
-// Note: the absolute path of the source directory is replaced with {repo}.
+// Note: the absolute path of the source directory is replaced with {local}.
 func (c *TPMRootsConfig) createFileURIPlaceholders(sourceDir string) error {
 	return c.transformFileURIPlaceholders(sourceDir /* isMarshal= */, true)
 }
@@ -164,8 +164,8 @@ func (c *Certificate) CheckAndSetDefault() error {
 		if !slices.Contains([]string{"https", "file"}, parsedURI.Scheme) {
 			return fmt.Errorf("invalid uri scheme '%s': must be 'https' or 'file'", parsedURI.Scheme)
 		}
-		if parsedURI.Scheme == "file" && !strings.Contains(c.URI, repoPlaceholder) {
-			return ErrMissingRepoPlaceholder
+		if parsedURI.Scheme == "file" && !strings.Contains(c.URI, localPlaceholder) {
+			return ErrMissingLocalPlaceholder
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,7 +164,7 @@ func (c *Certificate) CheckAndSetDefault() error {
 		if !slices.Contains([]string{"https", "file"}, parsedURI.Scheme) {
 			return fmt.Errorf("invalid uri scheme '%s': must be 'https' or 'file'", parsedURI.Scheme)
 		}
-		if parsedURI.Scheme == "file" && !strings.Contains(c.URI, localPlaceholder) {
+		if parsedURI.Scheme == "file" && !strings.Contains(parsedURI.Path, localPlaceholder) {
 			return ErrMissingLocalPlaceholder
 		}
 	}
@@ -308,12 +308,12 @@ func LoadConfig(path string) (*TPMRootsConfig, error) {
 //	    log.Fatal(err)
 //	}
 func SaveConfig(path string, cfg *TPMRootsConfig) error {
-	if err := cfg.CheckAndSetDefault(); err != nil {
-		return fmt.Errorf("invalid configuration: %w", err)
-	}
-
 	if err := cfg.createFileURIPlaceholders(filepath.Dir(path)); err != nil {
 		return fmt.Errorf("failed to create file URL placeholders: %w", err)
+	}
+
+	if err := cfg.CheckAndSetDefault(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	data, err := yaml.Marshal(cfg)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -470,6 +472,185 @@ func TestCertificate_Equal(t *testing.T) {
 			got := tt.cert1.Equal(tt.cert2)
 			if got != tt.want {
 				t.Errorf("Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadSaveConfig_FileURIPlaceholder tests the loading and saving of a config file containing file URI placeholders.
+//
+// Things work that way:
+// 1. LoadConfig: resolves {local} to absolute path
+// 2. SaveConfig: creates {local} placeholders before saving
+func TestLoadSaveConfig_FileURIPlaceholder(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".tpm-roots.yaml")
+
+	validYAML := `version: alpha
+vendors:
+- id: "TV"
+  name: "Test Vendor"
+  certificates:
+    - name: "Test Cert"
+      uri: "file:///{local}/certs/root.pem"
+      validation:
+        fingerprint:
+          sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
+`
+
+	if err := os.WriteFile(configPath, []byte(validYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load config - this resolves {local} to absolute path
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	// Verify that {local} has been resolved to absolute path after LoadConfig
+	certURI := cfg.Vendors[0].Certificates[0].URI
+	if strings.Contains(certURI, "{local}") {
+		t.Errorf("LoadConfig should resolve {local} placeholder, got: %s", certURI)
+	}
+	if !strings.HasPrefix(certURI, "file://") {
+		t.Errorf("Expected file:// URI, got: %s", certURI)
+	}
+
+	// SaveConfig must create placeholders before validation
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v, this validates that placeholders are created before validation", err)
+	}
+
+	// Verify that saved file contains {local} placeholder
+	savedData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(savedData, []byte("{local}")) {
+		t.Error("Saved file should contain {local} placeholder, not absolute path")
+	}
+}
+
+func TestCertificate_CheckAndSetDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		cert    Certificate
+		wantErr bool
+	}{
+		{
+			name: "valid certificate with https URI",
+			cert: Certificate{
+				Name: "Test",
+				URI:  "https://example.com/cert.pem",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid certificate with file URI and {local} placeholder",
+			cert: Certificate{
+				Name: "Test",
+				URI:  "file:///{local}/certs/root.pem",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid certificate with URL (deprecated)",
+			cert: Certificate{
+				Name: "Test",
+				URL:  "https://example.com/cert.pem",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			cert: Certificate{
+				URI: "https://example.com/cert.pem",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing URL and URI",
+			cert: Certificate{
+				Name: "Test",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid URI parse error",
+			cert: Certificate{
+				Name: "Test",
+				URI:  "://invalid",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid URI scheme",
+			cert: Certificate{
+				Name: "Test",
+				URI:  "ftp://example.com/cert.pem",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "file URI without {local} placeholder",
+			cert: Certificate{
+				Name: "Test",
+				URI:  "file:///absolute/path/cert.pem",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "file URI with {local} in query parameter (not in path)",
+			cert: Certificate{
+				Name: "Test",
+				URI:  "file:///absolute/path/cert.pem?param={local}",
+				Validation: Validation{
+					Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing fingerprint",
+			cert: Certificate{
+				Name:       "Test",
+				URI:        "https://example.com/cert.pem",
+				Validation: Validation{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cert.CheckAndSetDefault()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckAndSetDefault() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -180,7 +180,7 @@ func TestTPMRootsConfig_CheckAndSetDefault(t *testing.T) {
 						Certificates: []Certificate{
 							{
 								Name: "Test Cert",
-								URI:  "file:///{repo}/certs/root.pem",
+								URI:  "file:///{local}/certs/root.pem",
 								Validation: Validation{
 									Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
 								},
@@ -202,7 +202,7 @@ func TestTPMRootsConfig_CheckAndSetDefault(t *testing.T) {
 							{
 								Name: "Test Cert",
 								URL:  "https://example.com/cert.cer",
-								URI:  "file:///{repo}/certs/root.pem",
+								URI:  "file:///{local}/certs/root.pem",
 								Validation: Validation{
 									Fingerprint: Fingerprint{SHA1: "AA:BB:CC"},
 								},

--- a/internal/config/format/formatter_test.go
+++ b/internal/config/format/formatter_test.go
@@ -129,8 +129,8 @@ func TestEncodeURI(t *testing.T) {
 		},
 		{
 			name:  "file uri",
-			input: "file:///{repo}/path/to/cert.cer",
-			want:  "file:///{repo}/path/to/cert.cer",
+			input: "file:///{local}/path/to/cert.cer",
+			want:  "file:///{local}/path/to/cert.cer",
 		},
 		{
 			name:  "empty string",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated file-URI placeholder semantics to use a local placeholder for mapping paths.
  * Placeholder handling now occurs earlier in config save/load flow.

* **Bug Fixes**
  * Improved validation and clearer errors for file-based certificate URIs when the local placeholder is missing.

* **Tests**
  * Expanded and adjusted tests to cover the new placeholder behavior and URI validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loicsikidi/tpm-ca-certificates/pull/152)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->