### PR TITLE
fix: support URI in yaml validator

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,7 +188,11 @@ func (c *Certificate) GetSourceLocation() string {
 
 // IsRemoteSource returns true if the certificate source location is remote
 func (c *Certificate) IsRemoteSource() bool {
-	return strings.HasPrefix(c.GetSourceLocation(), "https://")
+	parsedURI, err := url.Parse(c.GetSourceLocation())
+	if err != nil {
+		return false
+	}
+	return slices.Contains([]string{"https", "http"}, parsedURI.Scheme)
 }
 
 // Equal checks if two certificates are considered equal based on Name, source location, or Fingerprint.

--- a/internal/config/validate/yaml_validator.go
+++ b/internal/config/validate/yaml_validator.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 
@@ -82,7 +83,7 @@ func (v *YAMLValidator) ValidateFile(path string) ([]ValidationError, error) {
 	v.validateVendorsSorting(cfg)
 	v.validateCertificatesSorting(cfg)
 	v.validateDuplicateCertificates(cfg)
-	v.validateURLEncoding(cfg)
+	v.validateURIEncoding(cfg)
 	v.validateFingerprintFormat(cfg)
 	v.validateQuotes(data)
 
@@ -254,33 +255,42 @@ func (v *YAMLValidator) validateDuplicateCertificates(cfg *config.TPMRootsConfig
 	}
 }
 
-// validateURLEncoding checks that URLs are properly encoded.
-func (v *YAMLValidator) validateURLEncoding(cfg *config.TPMRootsConfig) {
+// validateURIEncoding checks that URLs/URIs are properly encoded.
+func (v *YAMLValidator) validateURIEncoding(cfg *config.TPMRootsConfig) {
 	for i, vendor := range cfg.Vendors {
 		for j, cert := range vendor.Certificates {
-			//lint:ignore SA1019 transitioning from deprecated URL field to URI field
-			//nolint:staticcheck // SA1019: transitioning from deprecated URL field to URI field
-			parsedURL, err := url.Parse(cert.URL)
+			sourceLocation := cert.GetSourceLocation()
+			var fieldName string
+			if cert.URI != "" {
+				fieldName = "uri"
+			} else {
+				fieldName = "url"
+			}
+
+			parsedURL, err := url.Parse(sourceLocation)
 			if err != nil {
-				path := fmt.Sprintf("vendors[%d].certificates[%d].url", i, j)
-				v.addError(path, fmt.Sprintf("invalid URL: %v", err))
+				path := fmt.Sprintf("vendors[%d].certificates[%d].%s", i, j, fieldName)
+				v.addError(path, fmt.Sprintf("invalid %s: %v", fieldName, err))
 				continue
 			}
 
-			if parsedURL.Scheme != "https" {
-				path := fmt.Sprintf("vendors[%d].certificates[%d].url", i, j)
-				v.addError(path, fmt.Sprintf("URL must use HTTPS scheme: got %q", parsedURL.Scheme))
+			if fieldName == "uri" && !slices.Contains([]string{"https", "file"}, parsedURL.Scheme) {
+				path := fmt.Sprintf("vendors[%d].certificates[%d].%s", i, j, fieldName)
+				v.addError(path, fmt.Sprintf("%s must use HTTPS or file scheme: got %q", fieldName, parsedURL.Scheme))
+				continue
+			}
+
+			// For retrocompatibility with deprecated URL field
+			if fieldName == "url" && parsedURL.Scheme != "https" {
+				path := fmt.Sprintf("vendors[%d].certificates[%d].%s", i, j, fieldName)
+				v.addError(path, fmt.Sprintf("%s must use HTTPS scheme: got %q", fieldName, parsedURL.Scheme))
 				continue
 			}
 
 			encoded := parsedURL.String()
-			//lint:ignore SA1019 transitioning from deprecated URL field to URI field
-			//nolint:staticcheck // SA1019: transitioning from deprecated URL field to URI field
-			if encoded != cert.URL {
-				path := fmt.Sprintf("vendors[%d].certificates[%d].url", i, j)
-				//lint:ignore SA1019 transitioning from deprecated URL field to URI field
-				//nolint:staticcheck // SA1019: transitioning from deprecated URL field to URI field
-				v.addError(path, fmt.Sprintf("URL not properly encoded: got %q, expected %q", cert.URL, encoded))
+			if encoded != sourceLocation {
+				path := fmt.Sprintf("vendors[%d].certificates[%d].%s", i, j, fieldName)
+				v.addError(path, fmt.Sprintf("%s not properly encoded: got %q, expected %q", fieldName, sourceLocation, encoded))
 			}
 		}
 	}

--- a/internal/config/validate/yaml_validator_test.go
+++ b/internal/config/validate/yaml_validator_test.go
@@ -123,7 +123,7 @@ vendors:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
 `,
 			wantErrors:  1,
-			errorChecks: []string{"URL not properly encoded"},
+			errorChecks: []string{"url not properly encoded"},
 		},
 		{
 			name: "http URL",
@@ -140,7 +140,7 @@ vendors:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
 `,
 			wantErrors:  1,
-			errorChecks: []string{"URL must use HTTPS scheme"},
+			errorChecks: []string{"url must use HTTPS scheme"},
 		},
 		{
 			name: "lowercase fingerprint",
@@ -283,6 +283,114 @@ vendors:
 `,
 			wantErrors:  1,
 			errorChecks: []string{"duplicate certificate", "Cert B"},
+		},
+		{
+			name: "valid URI with https scheme",
+			yaml: `---
+version: "alpha"
+vendors:
+  - id: "STM"
+    name: "STMicroelectronics"
+    certificates:
+      - name: "Cert A"
+        uri: "https://example.com/cert.cer"
+        validation:
+          fingerprint:
+            sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
+`,
+			wantErrors: 0,
+		},
+		{
+			name: "valid URI with file scheme",
+			yaml: `---
+version: "alpha"
+vendors:
+  - id: "STM"
+    name: "STMicroelectronics"
+    certificates:
+      - name: "Cert A"
+        uri: "file:///{local}/certs/cert.der"
+        validation:
+          fingerprint:
+            sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
+`,
+			wantErrors: 0,
+		},
+		{
+			name: "unencoded URI",
+			yaml: `---
+version: "alpha"
+vendors:
+  - id: "STM"
+    name: "STMicroelectronics"
+    certificates:
+      - name: "Cert A"
+        uri: "https://example.com/cert with space.cer"
+        validation:
+          fingerprint:
+            sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
+`,
+			wantErrors:  1,
+			errorChecks: []string{"uri not properly encoded"},
+		},
+		{
+			name: "unencoded URI reports correct line number",
+			yaml: `---
+version: "alpha"
+vendors:
+  - id: "AMD"
+    name: "AMD"
+    certificates:
+      - name: "AMDTPM ECC"
+        description: "test certificate"
+        uri: "https://example.com/cert with space.der"
+        validation:
+          fingerprint:
+            sha256: "C2:CB:57:BF:72:3C:17:4F:16:6C:5A:A1:DC:64:16:09:81:05:4B:EE:18:C7:0E:B1:DE:BF:C1:51:8A:FA:92:D2"
+`,
+			wantErrors:  1,
+			errorChecks: []string{"uri not properly encoded"},
+		},
+		{
+			name: "unencoded URL reports correct line number",
+			yaml: `---
+version: "alpha"
+vendors:
+  - id: "AMD"
+    name: "AMD"
+    certificates:
+      - name: "AMDTPM ECC"
+        description: "test certificate"
+        url: "https://example.com/cert with space.der"
+        validation:
+          fingerprint:
+            sha256: "C2:CB:57:BF:72:3C:17:4F:16:6C:5A:A1:DC:64:16:09:81:05:4B:EE:18:C7:0E:B1:DE:BF:C1:51:8A:FA:92:D2"
+`,
+			wantErrors:  1,
+			errorChecks: []string{"url not properly encoded"},
+		},
+		{
+			name: "multiple unencoded URIs report correct line numbers",
+			yaml: `---
+version: "alpha"
+vendors:
+  - id: "AMD"
+    name: "AMD"
+    certificates:
+      - name: "Cert A"
+        uri: "https://valid.com/cert.der"
+        validation:
+          fingerprint:
+            sha256: "C2:CB:57:BF:72:3C:17:4F:16:6C:5A:A1:DC:64:16:09:81:05:4B:EE:18:C7:0E:B1:DE:BF:C1:51:8A:FA:92:D2"
+      - name: "Cert B"
+        description: "note: unencoded URI"
+        uri: "https://example.com/cert with space.der"
+        validation:
+          fingerprint:
+            sha256: "B7:3F:14:DE:A3:BD:AA:0B:E8:74:40:DE:3F:C7:18:C7:71:F2:CB:F8:B7:B2:23:1C:6E:A2:28:D3:B2:08:60:EF"
+`,
+			wantErrors:  1,
+			errorChecks: []string{"uri not properly encoded"},
 		},
 	}
 


### PR DESCRIPTION
Note: this cause 'config validate' to not working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for certificate URI field with validation for HTTPS and file schemes.

* **Bug Fixes**
  * Enhanced certificate remote source detection with improved URL parsing.
  * Updated validation for URI and deprecated URL fields with revised error messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loicsikidi/tpm-ca-certificates/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->