### PR TITLE
fix: regression in config format with file URI

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,10 +92,10 @@ func (c *TPMRootsConfig) resolveFileURIPlaceholders(sourceDir string) error {
 	return c.transformFileURIPlaceholders(sourceDir /* isMarshal= */, false)
 }
 
-// createFileURIPlaceholders replaces actual paths in file URIs with placeholders.
+// CreateFileURIPlaceholders replaces actual paths in file URIs with placeholders.
 //
 // Note: the absolute path of the source directory is replaced with {local}.
-func (c *TPMRootsConfig) createFileURIPlaceholders(sourceDir string) error {
+func (c *TPMRootsConfig) CreateFileURIPlaceholders(sourceDir string) error {
 	return c.transformFileURIPlaceholders(sourceDir /* isMarshal= */, true)
 }
 
@@ -312,7 +312,7 @@ func LoadConfig(path string) (*TPMRootsConfig, error) {
 //	    log.Fatal(err)
 //	}
 func SaveConfig(path string, cfg *TPMRootsConfig) error {
-	if err := cfg.createFileURIPlaceholders(filepath.Dir(path)); err != nil {
+	if err := cfg.CreateFileURIPlaceholders(filepath.Dir(path)); err != nil {
 		return fmt.Errorf("failed to create file URL placeholders: %w", err)
 	}
 

--- a/internal/config/format/formatter.go
+++ b/internal/config/format/formatter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -41,6 +42,15 @@ func (f *Formatter) NeedsFormatting(inputPath string) (bool, error) {
 	}
 
 	f.applyFormatting(cfg)
+
+	sourceDir, err := filepath.Abs(filepath.Dir(inputPath))
+	if err != nil {
+		return false, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	if err := cfg.CreateFileURIPlaceholders(sourceDir); err != nil {
+		return false, fmt.Errorf("failed to create file URI placeholders: %w", err)
+	}
 
 	formattedData, err := f.marshalWithQuotes(cfg)
 	if err != nil {
@@ -80,6 +90,15 @@ func (f *Formatter) FormatFile(inputPath, outputPath string) error {
 	}
 
 	f.applyFormatting(cfg)
+
+	sourceDir, err := filepath.Abs(filepath.Dir(outputPath))
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	if err := cfg.CreateFileURIPlaceholders(sourceDir); err != nil {
+		return fmt.Errorf("failed to create file URI placeholders: %w", err)
+	}
 
 	yamlData, err := f.marshalWithQuotes(cfg)
 	if err != nil {


### PR DESCRIPTION
Note: this commit replace internally file URI with {local} placeholder as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Configuration files now properly process file URI placeholders during save and format operations. Absolute file paths are replaced with placeholders to improve portability across different systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loicsikidi/tpm-ca-certificates/pull/154)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->