### PR TITLE
fix: reword URL to Source in 'certificates list'

### DIFF
--- a/cmd/config/certificates/list.go
+++ b/cmd/config/certificates/list.go
@@ -72,9 +72,7 @@ func runList(opts *listOptions) error {
 
 		for _, cert := range vendor.Certificates {
 			fmt.Printf("  Certificate: %s\n", cert.Name)
-			//lint:ignore SA1019 transitioning from deprecated URL field to URI field
-			//nolint:staticcheck // SA1019: transitioning from deprecated URL field to URI field
-			fmt.Printf("    URL: %s\n", cert.URL)
+			fmt.Printf("    Source: %s\n", cert.GetSourceLocation())
 
 			fp := cert.Validation.Fingerprint
 			hasFingerprints := false

--- a/cmd/config/certificates/list_test.go
+++ b/cmd/config/certificates/list_test.go
@@ -48,7 +48,7 @@ vendors:
 			expectedOutput: []string{
 				"Vendor: Vendor A (ID: VDA)",
 				"Certificate: Cert A1",
-				"URL: https://example.com/a1.crt",
+				"Source: https://example.com/a1.crt",
 				"SHA1:",
 				"Certificate: Cert A2",
 				"SHA256:",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated certificate list command output to display source location information instead of URL field.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loicsikidi/tpm-ca-certificates/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->