### PR TITLE
feat(config): add AllowHttpFallback to Certificate

### DIFF
--- a/cmd/config/certificates/add.go
+++ b/cmd/config/certificates/add.go
@@ -400,7 +400,10 @@ func downloadCertificatesParallel(ctx context.Context, urls []string, fingerprin
 
 		// Download certificate
 		client := download.NewClient()
-		cert, err := client.FetchCertificate(ctx, input.url)
+		tempCert := config.Certificate{
+			URI: input.url,
+		}
+		cert, err := client.FetchCertificate(ctx, tempCert)
 		if err != nil {
 			result.err = err
 			return result

--- a/docs/specifications/01-configuration-file.md
+++ b/docs/specifications/01-configuration-file.md
@@ -10,6 +10,7 @@
 | 2026-04-11 | Loïc Sikidi | Add optional description field to Certificate |
 | 2026-05-10 | Loïc Sikidi | Add URI support with file:// scheme           |
 | 2026-05-13 | Loïc Sikidi | Promote to beta, remove url field             |
+| 2026-05-15 | Loïc Sikidi | Add allowHttpFallback field to Certificate    |
 
 The TPM Trust Bundle is generated from two human-readable YAML configuration files:
 
@@ -42,6 +43,7 @@ vendors:
         - name: "Certificate Name"
           description: "Optional description of this certificate"
           uri: "https://vendor.com/path/to/certificate.cer"
+          allowHttpFallback: false  # Optional, defaults to false
           validation:
             fingerprint:
                 sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -62,6 +64,7 @@ vendors:
 | `vendors[].certificates[].name` | string | Yes | Human-readable certificate name | `"Nuvoton TPM Root CA 1110"` |
 | `vendors[].certificates[].description` | string | No | Optional human-readable description of the certificate | `"This certificate is used for TPM 2.0 devices"` |
 | `vendors[].certificates[].uri` | string | Yes | URI where the certificate can be accessed. Supports `https://` (nominal case for publicly available certificates) or `file:///` (exceptional case for archived certificates). File URIs must use the `/{local}` placeholder pattern: `file:///{local}/relative/path`. | `"https://www.nuvoton.com/..."` or `"file:///{local}/certs/archived.cer"` |
+| `vendors[].certificates[].allowHttpFallback` | boolean | No | Allow fallback to HTTP if HTTPS fails (defaults to `false`). Use with extreme caution - should only be enabled for servers with broken HTTPS configurations. Security is maintained through fingerprint validation. | `true` |
 | `vendors[].certificates[].validation` | object | Yes | Validation information for the certificate | - |
 | `vendors[].certificates[].validation.fingerprint` | object | Yes | Hash fingerprints of the certificate | - |
 | `vendors[].certificates[].validation.fingerprint.sha1` | string | No | SHA-1 fingerprint | `"65:5E:44:5E:96:54:..."` |
@@ -326,6 +329,24 @@ uri: "file://certs/certificate.cer"
 > File URIs should only be used for exceptional cases where certificates are no longer publicly available and need to be archived in the repository. HTTPS URIs are the nominal case for publicly available certificates.
 >
 > The `/{local}` placeholder is dynamically replaced by the CLI with the absolute path of the configuration file's parent directory.
+
+#### HTTP Fallback (Security Consideration)
+
+The `allowHttpFallback` field controls whether the certificate downloader should attempt HTTP retrieval if HTTPS fails. This field exists to handle servers with broken HTTPS configurations (e.g., TLS certificate hostname mismatch).
+
+```yaml
+# ✓ Acceptable use case - server with broken HTTPS
+certificates:
+  - name: "Certificate from problematic server"
+    uri: "https://pki.example.com/cert.cer"
+    allowHttpFallback: true
+    validation:
+      fingerprint:
+        sha256: "AA:BB:CC:..."
+```
+
+> [!WARNING]
+> Use `allowHttpFallback: true` sparingly and only when absolutely necessary. While certificate integrity is guaranteed through fingerprint validation, HTTP fallback reduces transport security guarantees. This field should only be enabled for servers with known HTTPS configuration issues that cannot be resolved.
 
 ### 5. Fingerprint Format
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caarlos0/go-version v0.2.2
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/loicsikidi/go-tpm-kit v0.6.1
-	github.com/loicsikidi/go-utils v0.1.3
+	github.com/loicsikidi/go-utils v0.3.0
 	github.com/sigstore/sigstore-go v1.1.5-0.20260202082308-3f2ee9eda9b2
 	github.com/spf13/cobra v1.10.2
 	github.com/theupdateframework/go-tuf/v2 v2.4.1

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/letsencrypt/boulder v0.20251110.0 h1:J8MnKICeilO91dyQ2n5eBbab24neHzUp
 github.com/letsencrypt/boulder v0.20251110.0/go.mod h1:ogKCJQwll82m7OVHWyTuf8eeFCjuzdRQlgnZcCl0V+8=
 github.com/loicsikidi/go-tpm-kit v0.6.1 h1:M688tAxu8nzA4zr2x07c2c3uJx8LVijXFXW63yBd8/c=
 github.com/loicsikidi/go-tpm-kit v0.6.1/go.mod h1:NaWraIy5YnNsBLFaqIrftAr7L0bth4shh1bnKquIOe4=
-github.com/loicsikidi/go-utils v0.1.3 h1:fZSgO1PdV8vKrn7AolHvrgcvm51kiB8C17Ofwc4eC9E=
-github.com/loicsikidi/go-utils v0.1.3/go.mod h1:X/r13jNC33jGachqUxrSPw6LkirfTRh1traFLmpxxzc=
+github.com/loicsikidi/go-utils v0.3.0 h1:4iMjwNtVFRHWwGj5+Y64HNv0n0vPoiXG465iyPle3Tc=
+github.com/loicsikidi/go-utils v0.3.0/go.mod h1:X/r13jNC33jGachqUxrSPw6LkirfTRh1traFLmpxxzc=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/internal/bundle/generator.go
+++ b/internal/bundle/generator.go
@@ -201,7 +201,7 @@ func (g *Generator) GenerateWithMetadata(cfg *config.TPMRootsConfig, workers int
 
 // processCertificate downloads, validates, and converts a certificate to PEM with a comment header.
 func (g *Generator) processCertificate(cert config.Certificate, vendorID string) (string, error) {
-	x509Cert, err := g.downloader.FetchCertificate(context.Background(), cert.GetSourceLocation())
+	x509Cert, err := g.downloader.FetchCertificate(context.Background(), cert)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,10 +140,11 @@ func (v *Vendor) CheckAndSetDefault() error {
 type Certificate struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description,omitempty"`
+	URI         string `yaml:"uri,omitempty"`
 	// Deprecated: Use URI instead.
-	URL        string     `yaml:"url,omitempty"`
-	URI        string     `yaml:"uri,omitempty"`
-	Validation Validation `yaml:"validation"`
+	URL               string     `yaml:"url,omitempty"`
+	AllowHttpFallback bool       `yaml:"allowHttpFallback,omitempty"`
+	Validation        Validation `yaml:"validation"`
 }
 
 // CheckAndSetDefault validates a Certificate.

--- a/internal/config/download/download.go
+++ b/internal/config/download/download.go
@@ -10,6 +10,7 @@ import (
 
 	goutils "github.com/loicsikidi/go-utils"
 	"github.com/loicsikidi/go-utils/net/httputil"
+	"github.com/loicsikidi/tpm-ca-certificates/internal/config"
 	"github.com/loicsikidi/tpm-ca-certificates/internal/config/download/source"
 	"github.com/loicsikidi/tpm-ca-certificates/internal/utils"
 )
@@ -59,17 +60,22 @@ func (c *Client) DownloadCertificate(ctx context.Context, url string) (*x509.Cer
 	return cert, nil
 }
 
-// FetchCertificate retrieves a certificate from a URI (supports https:// and file:// schemes).
+// FetchCertificate retrieves a certificate from a [config.Certificate].
 //
 // Example:
 //
 //	client := download.NewClient()
-//	cert, err := client.FetchCertificate(ctx, "file:///home/user/repo/certs/root.pem")
+//	cert := config.Certificate{
+//	    URI:               "file:///home/user/repo/certs/root.pem",
+//	    AllowHttpFallback: false,
+//	}
+//	x509Cert, err := client.FetchCertificate(ctx, cert)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-func (c *Client) FetchCertificate(ctx context.Context, uri string) (*x509.Certificate, error) {
-	resolver, err := source.NewResolver(uri, c.HTTPClient)
+func (c *Client) FetchCertificate(ctx context.Context, cert config.Certificate) (*x509.Certificate, error) {
+	uri := cert.GetSourceLocation()
+	resolver, err := source.NewResolver(source.Config{URI: uri, HttpClient: c.HTTPClient, AllowHttpFallback: cert.AllowHttpFallback})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resolver for %s: %w", uri, err)
 	}
@@ -79,12 +85,12 @@ func (c *Client) FetchCertificate(ctx context.Context, uri string) (*x509.Certif
 		return nil, fmt.Errorf("failed to fetch certificate from %s: %w", uri, err)
 	}
 
-	cert, err := ParseCertificate(data)
+	x509Cert, err := ParseCertificate(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse certificate from %s: %w", uri, err)
 	}
 
-	return cert, nil
+	return x509Cert, nil
 }
 
 // ParseCertificate attempts to parse a certificate from DER or PEM format.

--- a/internal/config/download/download_test.go
+++ b/internal/config/download/download_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/loicsikidi/tpm-ca-certificates/internal/config"
 	"github.com/loicsikidi/tpm-ca-certificates/internal/config/download"
 	"github.com/loicsikidi/tpm-ca-certificates/internal/testutil"
 )
@@ -123,7 +124,8 @@ func TestFetchCertificate(t *testing.T) {
 		defer server.Close()
 
 		client := download.NewClient(server.Client())
-		_, err := client.FetchCertificate(t.Context(), server.URL)
+		cert := config.Certificate{URI: server.URL}
+		_, err := client.FetchCertificate(t.Context(), cert)
 		if err != nil {
 			t.Fatalf("FetchCertificate() error = %v", err)
 		}
@@ -145,7 +147,8 @@ func TestFetchCertificate(t *testing.T) {
 
 		client := download.NewClient()
 		uri := "file://" + certPath
-		_, err := client.FetchCertificate(t.Context(), uri)
+		cert := config.Certificate{URI: uri}
+		_, err := client.FetchCertificate(t.Context(), cert)
 		if err != nil {
 			t.Fatalf("FetchCertificate() error = %v", err)
 		}
@@ -153,7 +156,8 @@ func TestFetchCertificate(t *testing.T) {
 
 	t.Run("returns error for unsupported scheme", func(t *testing.T) {
 		client := download.NewClient()
-		_, err := client.FetchCertificate(t.Context(), "ftp://example.com/cert.cer")
+		cert := config.Certificate{URI: "ftp://example.com/cert.cer"}
+		_, err := client.FetchCertificate(t.Context(), cert)
 		if err == nil {
 			t.Error("FetchCertificate() expected error for unsupported scheme")
 		}
@@ -164,7 +168,8 @@ func TestFetchCertificate(t *testing.T) {
 
 	t.Run("returns error for non-existent file", func(t *testing.T) {
 		client := download.NewClient()
-		_, err := client.FetchCertificate(t.Context(), "file:///non/existent/cert.pem")
+		cert := config.Certificate{URI: "file:///non/existent/cert.pem"}
+		_, err := client.FetchCertificate(t.Context(), cert)
 		if err == nil {
 			t.Error("FetchCertificate() expected error for non-existent file")
 		}
@@ -180,7 +185,8 @@ func TestFetchCertificate(t *testing.T) {
 
 		client := download.NewClient()
 		uri := "file://" + certPath
-		_, err := client.FetchCertificate(t.Context(), uri)
+		cert := config.Certificate{URI: uri}
+		_, err := client.FetchCertificate(t.Context(), cert)
 		if err == nil {
 			t.Error("FetchCertificate() expected error for invalid certificate")
 		}

--- a/internal/config/download/source/resolver.go
+++ b/internal/config/download/source/resolver.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	goutils "github.com/loicsikidi/go-utils"
 	"github.com/loicsikidi/go-utils/net/httputil"
 	"github.com/loicsikidi/go-utils/system/fsutil"
 
@@ -28,22 +27,33 @@ type Resolver interface {
 
 // HTTPSResolver downloads certificates from HTTPS URLs.
 type HTTPSResolver struct {
-	url        string
-	httpClient utils.HTTPClient
+	url               string
+	httpClient        utils.HTTPClient
+	allowHttpFallback bool
 }
 
 // NewHTTPSResolver creates a new HTTPS resolver.
-func NewHTTPSResolver(url string, httpClient utils.HTTPClient) *HTTPSResolver {
+func NewHTTPSResolver(url string, httpClient utils.HTTPClient, allowHttpFallback bool) *HTTPSResolver {
 	return &HTTPSResolver{
-		url:        url,
-		httpClient: httpClient,
+		url:               url,
+		httpClient:        httpClient,
+		allowHttpFallback: allowHttpFallback,
 	}
 }
 
 // Fetch downloads the certificate from the HTTPS URL.
+// If HTTPS fails and allowHttpFallback is true, attempts HTTP as fallback.
 func (r *HTTPSResolver) Fetch(ctx context.Context) ([]byte, error) {
 	data, err := httputil.HttpGET(ctx, r.httpClient, r.url)
 	if err != nil {
+		if r.allowHttpFallback {
+			httpURL := strings.Replace(r.url, "https://", "http://", 1)
+			data, httpErr := httputil.HttpGET(ctx, r.httpClient, httpURL)
+			if httpErr != nil {
+				return nil, fmt.Errorf("failed to download from %s (HTTPS error: %w) and HTTP fallback from %s failed: %v", r.url, err, httpURL, httpErr)
+			}
+			return data, nil
+		}
 		return nil, fmt.Errorf("failed to download from %s: %w", r.url, err)
 	}
 	return data, nil
@@ -75,6 +85,22 @@ func (r *FileResolver) Fetch(ctx context.Context) ([]byte, error) {
 	return data, nil
 }
 
+type Config struct {
+	URI               string
+	HttpClient        utils.HTTPClient
+	AllowHttpFallback bool
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if c.HttpClient == nil {
+		c.HttpClient = defaultClient
+	}
+	if c.URI == "" {
+		return fmt.Errorf("uri must be provided")
+	}
+	return nil
+}
+
 // NewResolver creates the appropriate resolver based on the URI scheme.
 //
 // Supported schemes:
@@ -84,22 +110,25 @@ func (r *FileResolver) Fetch(ctx context.Context) ([]byte, error) {
 // Example:
 //
 //	// HTTPS resolver
-//	resolver, err := NewResolver("https://example.com/cert.cer", httpClient)
+//	resolver, err := NewResolver(Config{URI: "https://example.com/cert.cer"})
 //
 //	// File resolver (absolute)
-//	resolver, err := NewResolver("file:///home/user/repo/certs/root.pem")
-func NewResolver(uri string, optionalHttpClient ...utils.HTTPClient) (Resolver, error) {
-	parsedURI, err := url.Parse(uri)
+//	resolver, err := NewResolver(Config{URI: "file:///home/user/repo/certs/root.pem"})
+func NewResolver(config Config) (Resolver, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, err
+	}
+
+	parsedURI, err := url.Parse(config.URI)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URI: %w", err)
 	}
 
 	switch parsedURI.Scheme {
 	case "https":
-		httpClient := goutils.OptionalArgWithDefault[utils.HTTPClient](optionalHttpClient, defaultClient)
-		return NewHTTPSResolver(uri, httpClient), nil
+		return NewHTTPSResolver(config.URI, config.HttpClient, config.AllowHttpFallback), nil
 	case "file":
-		return NewFileResolver(uri)
+		return NewFileResolver(config.URI)
 	default:
 		return nil, fmt.Errorf("unsupported URI scheme '%s': must be 'https' or 'file'", parsedURI.Scheme)
 	}

--- a/internal/config/download/source/resolver_test.go
+++ b/internal/config/download/source/resolver_test.go
@@ -19,7 +19,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 		}))
 		defer server.Close()
 
-		resolver := NewHTTPSResolver(server.URL, server.Client())
+		resolver := NewHTTPSResolver(server.URL, server.Client(), false)
 		data, err := resolver.Fetch(context.Background())
 
 		if err != nil {
@@ -37,7 +37,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 		}))
 		defer server.Close()
 
-		resolver := NewHTTPSResolver(server.URL, server.Client())
+		resolver := NewHTTPSResolver(server.URL, server.Client(), false)
 		_, err := resolver.Fetch(context.Background())
 
 		if err == nil {
@@ -55,7 +55,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 		}))
 		defer server.Close()
 
-		resolver := NewHTTPSResolver(server.URL, server.Client())
+		resolver := NewHTTPSResolver(server.URL, server.Client(), false)
 		_, err := resolver.Fetch(context.Background())
 
 		if err == nil {
@@ -76,7 +76,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		resolver := NewHTTPSResolver(server.URL, server.Client())
+		resolver := NewHTTPSResolver(server.URL, server.Client(), false)
 		_, err := resolver.Fetch(ctx)
 
 		if err == nil {
@@ -92,7 +92,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 		}))
 		defer server.Close()
 
-		resolver := NewHTTPSResolver(server.URL, server.Client())
+		resolver := NewHTTPSResolver(server.URL, server.Client(), false)
 		data, err := resolver.Fetch(context.Background())
 
 		if err != nil {
@@ -266,7 +266,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("creates HTTPS resolver", func(t *testing.T) {
 		uri := "https://example.com/cert.cer"
 
-		resolver, err := NewResolver(uri)
+		resolver, err := NewResolver(Config{URI: uri})
 
 		if err != nil {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
@@ -282,7 +282,7 @@ func TestNewResolver(t *testing.T) {
 		uri := "https://example.com/cert.cer"
 		customClient := &http.Client{}
 
-		resolver, err := NewResolver(uri, customClient)
+		resolver, err := NewResolver(Config{URI: uri, HttpClient: customClient})
 
 		if err != nil {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
@@ -301,7 +301,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("creates file resolver with absolute path", func(t *testing.T) {
 		uri := "file:///home/user/cert.pem"
 
-		resolver, err := NewResolver(uri)
+		resolver, err := NewResolver(Config{URI: uri})
 
 		if err != nil {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
@@ -316,7 +316,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("rejects http scheme", func(t *testing.T) {
 		uri := "http://example.com/cert.cer"
 
-		_, err := NewResolver(uri)
+		_, err := NewResolver(Config{URI: uri})
 
 		if err == nil {
 			t.Fatal("NewResolver() error = nil, want error for http scheme")
@@ -330,7 +330,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("rejects ftp scheme", func(t *testing.T) {
 		uri := "ftp://example.com/cert.cer"
 
-		_, err := NewResolver(uri)
+		_, err := NewResolver(Config{URI: uri})
 
 		if err == nil {
 			t.Fatal("NewResolver() error = nil, want error for ftp scheme")
@@ -344,7 +344,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("rejects empty scheme", func(t *testing.T) {
 		uri := "example.com/cert.cer"
 
-		_, err := NewResolver(uri)
+		_, err := NewResolver(Config{URI: uri})
 
 		if err == nil {
 			t.Fatal("NewResolver() error = nil, want error for missing scheme")
@@ -358,7 +358,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("handles invalid URI", func(t *testing.T) {
 		uri := "://invalid"
 
-		_, err := NewResolver(uri)
+		_, err := NewResolver(Config{URI: uri})
 
 		if err == nil {
 			t.Fatal("NewResolver() error = nil, want error for invalid URI")
@@ -372,7 +372,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("rejects file resolver with relative path", func(t *testing.T) {
 		uri := "file://certs/cert.pem"
 
-		_, err := NewResolver(uri)
+		_, err := NewResolver(Config{URI: uri})
 
 		if err == nil {
 			t.Fatal("NewResolver() error = nil, want error for relative path")
@@ -386,7 +386,7 @@ func TestNewResolver(t *testing.T) {
 	t.Run("uses default HTTP client when none provided", func(t *testing.T) {
 		uri := "https://example.com/cert.cer"
 
-		resolver, err := NewResolver(uri)
+		resolver, err := NewResolver(Config{URI: uri})
 
 		if err != nil {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
@@ -402,12 +402,11 @@ func TestNewResolver(t *testing.T) {
 		}
 	})
 
-	t.Run("ignores additional HTTP client parameters", func(t *testing.T) {
+	t.Run("uses provided HTTP client", func(t *testing.T) {
 		uri := "https://example.com/cert.cer"
 		client1 := &http.Client{}
-		client2 := &http.Client{}
 
-		resolver, err := NewResolver(uri, client1, client2)
+		resolver, err := NewResolver(Config{URI: uri, HttpClient: client1})
 
 		if err != nil {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
@@ -419,7 +418,7 @@ func TestNewResolver(t *testing.T) {
 		}
 
 		if httpsResolver.httpClient != client1 {
-			t.Error("NewResolver() should use first HTTP client only")
+			t.Error("NewResolver() should use provided HTTP client")
 		}
 	})
 }
@@ -433,7 +432,7 @@ func TestResolver_Integration(t *testing.T) {
 		}))
 		defer server.Close()
 
-		resolver, err := NewResolver(server.URL, server.Client())
+		resolver, err := NewResolver(Config{URI: server.URL, HttpClient: server.Client()})
 		if err != nil {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
 		}
@@ -458,7 +457,7 @@ func TestResolver_Integration(t *testing.T) {
 		}
 
 		uri := "file://" + testFile
-		resolver, err := NewResolver(uri)
+		resolver, err := NewResolver(Config{URI: uri})
 		if err != nil {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
 		}

--- a/internal/config/sanity/sanity.go
+++ b/internal/config/sanity/sanity.go
@@ -164,7 +164,7 @@ func (c *Checker) Check(cfg *config.TPMRootsConfig, workers int, thresholdDays i
 
 // checkCertificate validates a single certificate and checks its expiration.
 func (c *Checker) checkCertificate(cert config.Certificate, vendorID, vendorName string, thresholdDays int) (*ValidationError, *ExpirationWarning, error) {
-	x509Cert, err := c.downloader.FetchCertificate(context.Background(), cert.GetSourceLocation())
+	x509Cert, err := c.downloader.FetchCertificate(context.Background(), cert)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to download certificate %q from vendor %q: %w", cert.Name, vendorName, err)
 	}


### PR DESCRIPTION
fixes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP fallback configuration for certificate downloads. When enabled, the system may attempt HTTP retrieval if HTTPS fails. Fingerprint validation preserves integrity.

* **Refactoring**
  * Refactored internal certificate fetching to use a configuration-based API.

* **Dependencies**
  * Updated go-utils dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loicsikidi/tpm-ca-certificates/pull/165)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->