### PR TITLE
refactor(test): minor changes

### DIFF
--- a/cmd/config/certificates/list_test.go
+++ b/cmd/config/certificates/list_test.go
@@ -25,12 +25,12 @@ vendors:
     name: "Vendor A"
     certificates:
       - name: "Cert A1"
-        url: "https://example.com/a1.crt"
+        uri: "https://example.com/a1.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Cert A2"
-        url: "https://example.com/a2.crt"
+        uri: "https://example.com/a2.crt"
         validation:
           fingerprint:
             sha256: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00"
@@ -38,7 +38,7 @@ vendors:
     name: "Vendor B"
     certificates:
       - name: "Cert B1"
-        url: "https://example.com/b1.crt"
+        uri: "https://example.com/b1.crt"
         validation:
           fingerprint:
             sha1: "FF:EE:DD:CC:BB:AA:99:88:77:66:55:44:33:22:11:00:FF:EE:DD:CC"
@@ -64,7 +64,7 @@ vendors:
     name: "Vendor A"
     certificates:
       - name: "Cert A1"
-        url: "https://example.com/a1.crt"
+        uri: "https://example.com/a1.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -72,7 +72,7 @@ vendors:
     name: "Vendor B"
     certificates:
       - name: "Cert B1"
-        url: "https://example.com/b1.crt"
+        uri: "https://example.com/b1.crt"
         validation:
           fingerprint:
             sha1: "FF:EE:DD:CC:BB:AA:99:88:77:66:55:44:33:22:11:00:FF:EE:DD:CC"
@@ -94,7 +94,7 @@ vendors:
     name: "Vendor A"
     certificates:
       - name: "Cert A1"
-        url: "https://example.com/a1.crt"
+        uri: "https://example.com/a1.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -112,7 +112,7 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Multi-Hash Cert"
-        url: "https://example.com/multi.crt"
+        uri: "https://example.com/multi.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"

--- a/cmd/config/certificates/remove_test.go
+++ b/cmd/config/certificates/remove_test.go
@@ -24,17 +24,17 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Certificate A"
-        url: "https://example.com/cert-a.crt"
+        uri: "https://example.com/cert-a.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Certificate B"
-        url: "https://example.com/cert-b.crt"
+        uri: "https://example.com/cert-b.crt"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"
       - name: "Certificate C"
-        url: "https://example.com/cert-c.crt"
+        uri: "https://example.com/cert-c.crt"
         validation:
           fingerprint:
             sha1: "FF:EE:DD:CC:BB:AA:99:88:77:66:55:44:33:22:11:00:FF:EE:DD:CC"
@@ -68,12 +68,12 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "FirstCert"
-        url: "https://example.com/first.crt"
+        uri: "https://example.com/first.crt"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"
       - name: "MyTestCertificate"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -101,7 +101,7 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Test Cert"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -120,7 +120,7 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Certificate A"
-        url: "https://example.com/cert-a.crt"
+        uri: "https://example.com/cert-a.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -139,12 +139,12 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "First Cert"
-        url: "https://example.com/first.crt"
+        uri: "https://example.com/first.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Second Cert"
-        url: "https://example.com/second.crt"
+        uri: "https://example.com/second.crt"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"
@@ -172,12 +172,12 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "First Cert"
-        url: "https://example.com/first.crt"
+        uri: "https://example.com/first.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Last Cert"
-        url: "https://example.com/last.crt"
+        uri: "https://example.com/last.crt"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"

--- a/cmd/config/format/format_test.go
+++ b/cmd/config/format/format_test.go
@@ -24,7 +24,7 @@ vendors:
     name: Test Vendor
     certificates:
       - name: Test Cert
-        url: https://example.com/test.cer
+        uri: https://example.com/test.cer
         validation:
           fingerprint:
             sha1: aa:bb:cc:dd
@@ -72,7 +72,7 @@ vendors:
     name: "Vendor B"
     certificates:
       - name: "Cert"
-        url: "https://example.com/b.cer"
+        uri: "https://example.com/b.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"
@@ -80,7 +80,7 @@ vendors:
     name: "Vendor A"
     certificates:
       - name: "Cert"
-        url: "https://example.com/a.cer"
+        uri: "https://example.com/a.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"
@@ -113,12 +113,12 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Z Certificate"
-        url: "https://example.com/z.cer"
+        uri: "https://example.com/z.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"
       - name: "A Certificate"
-        url: "https://example.com/a.cer"
+        uri: "https://example.com/a.cer"
         validation:
           fingerprint:
             sha1: "EE:FF:00:11"
@@ -153,7 +153,7 @@ vendors:
     name: Test Vendor
     certificates:
       - name: Test Cert
-        url: https://example.com/test.cer
+        uri: https://example.com/test.cer
         validation:
           fingerprint:
             sha1: aa:bb:cc:dd
@@ -186,7 +186,7 @@ vendors:
       name: "Test Vendor"
       certificates:
         - name: "Test Cert"
-          url: "https://example.com/test.cer"
+          uri: "https://example.com/test.cer"
           validation:
             fingerprint:
                 sha1: "AA:BB:CC:DD"
@@ -215,7 +215,7 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Test Cert"
-        url: "https://example.com/test cert with spaces.cer"
+        uri: "https://example.com/test cert with spaces.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"
@@ -316,7 +316,7 @@ vendors:
     name: "Test"
     certificates:
       - name: "Cert"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "aa:bb:cc:dd"
@@ -332,7 +332,7 @@ vendors:
     name: Test
     certificates:
       - name: Cert
-        url: https://example.com/cert.cer
+        uri: https://example.com/cert.cer
         validation:
           fingerprint:
             sha1: aa:bb:cc:dd
@@ -349,7 +349,7 @@ vendors:
       name: "Test"
       certificates:
         - name: "Cert"
-          url: "https://example.com/cert.cer"
+          uri: "https://example.com/cert.cer"
           validation:
             fingerprint:
                 sha1: "AA:BB:CC:DD"

--- a/cmd/config/sanity/sanity_test.go
+++ b/cmd/config/sanity/sanity_test.go
@@ -117,7 +117,7 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Test Certificate"
-        url: "` + server.URL + `"
+        uri: "` + server.URL + `"
         validation:
           fingerprint:
             sha1: "` + formatFingerprintWithColons(fingerprint) + `"
@@ -235,7 +235,7 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Test Certificate"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha256: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"

--- a/cmd/config/validate/validate_test.go
+++ b/cmd/config/validate/validate_test.go
@@ -26,7 +26,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Test Certificate"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha256: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
@@ -45,7 +45,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Test Certificate"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha256: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
@@ -63,7 +63,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Test Certificate"
-        url: "http://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha256: "invalid-fingerprint"
@@ -82,7 +82,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Test Certificate"
-        url: "http://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha256: "invalid-fingerprint"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -280,7 +280,7 @@ vendors:
   name: "Test Vendor"
   certificates:
     - name: "Test Cert"
-      url: "https://example.com/cert.cer"
+      uri: "https://example.com/cert.cer"
       validation:
         fingerprint:
           sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"

--- a/internal/config/download/source/resolver_test.go
+++ b/internal/config/download/source/resolver_test.go
@@ -23,7 +23,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 			/* optionalUseTLS= */ true)
 		resolver := NewHTTPSResolver(uri, srv.Client(),
 			/* allowHttpFallback= */ false)
-		data, err := resolver.Fetch(context.Background())
+		data, err := resolver.Fetch(t.Context())
 		if err != nil {
 			t.Fatalf("Fetch() error = %v, want nil", err)
 		}
@@ -40,7 +40,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 
 		resolver := NewHTTPSResolver(invalidURL, srv.Client(),
 			/* allowHttpFallback= */ false)
-		_, err := resolver.Fetch(context.Background())
+		_, err := resolver.Fetch(t.Context())
 		if err == nil {
 			t.Fatal("Fetch() error = nil, want error")
 		}
@@ -56,7 +56,7 @@ func TestHTTPSResolver_Fetch(t *testing.T) {
 		}))
 		defer server.Close()
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
 		resolver := NewHTTPSResolver(server.URL, server.Client(), false)
@@ -142,7 +142,7 @@ func TestFileResolver_Fetch(t *testing.T) {
 			t.Fatalf("NewFileResolver() error = %v, want nil", err)
 		}
 
-		data, err := resolver.Fetch(context.Background())
+		data, err := resolver.Fetch(t.Context())
 
 		if err != nil {
 			t.Fatalf("Fetch() error = %v, want nil", err)
@@ -161,7 +161,7 @@ func TestFileResolver_Fetch(t *testing.T) {
 			t.Fatalf("NewFileResolver() error = %v, want nil", err)
 		}
 
-		_, err = resolver.Fetch(context.Background())
+		_, err = resolver.Fetch(t.Context())
 
 		if err == nil {
 			t.Fatal("Fetch() error = nil, want error for non-existent file")
@@ -185,7 +185,7 @@ func TestFileResolver_Fetch(t *testing.T) {
 			t.Fatalf("NewFileResolver() error = %v, want nil", err)
 		}
 
-		data, err := resolver.Fetch(context.Background())
+		data, err := resolver.Fetch(t.Context())
 
 		if err != nil {
 			t.Fatalf("Fetch() error = %v, want nil", err)
@@ -210,7 +210,7 @@ func TestFileResolver_Fetch(t *testing.T) {
 			t.Fatalf("NewFileResolver() error = %v, want nil", err)
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
 		data, err := resolver.Fetch(ctx)
@@ -356,7 +356,7 @@ func TestResolver_Integration(t *testing.T) {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
 		}
 
-		data, err := resolver.Fetch(context.Background())
+		data, err := resolver.Fetch(t.Context())
 		if err != nil {
 			t.Fatalf("Fetch() error = %v, want nil", err)
 		}
@@ -399,7 +399,7 @@ func TestResolver_Integration(t *testing.T) {
 		}
 
 		// Should fail because HTTP fallback is disabled
-		_, err = resolver.Fetch(context.Background())
+		_, err = resolver.Fetch(t.Context())
 		if err == nil {
 			t.Fatal("Fetch() error = nil, want error because HTTP fallback is disabled")
 		}
@@ -415,7 +415,7 @@ func TestResolver_Integration(t *testing.T) {
 		}
 
 		// Should succeed because HTTP fallback is enabled
-		data, err := resolver.Fetch(context.Background())
+		data, err := resolver.Fetch(t.Context())
 		if err != nil {
 			t.Fatalf("Fetch() error = %v, want nil", err)
 		}
@@ -440,7 +440,7 @@ func TestResolver_Integration(t *testing.T) {
 			t.Fatalf("NewResolver() error = %v, want nil", err)
 		}
 
-		data, err := resolver.Fetch(context.Background())
+		data, err := resolver.Fetch(t.Context())
 		if err != nil {
 			t.Fatalf("Fetch() error = %v, want nil", err)
 		}

--- a/internal/config/format/formatter_test.go
+++ b/internal/config/format/formatter_test.go
@@ -234,7 +234,7 @@ vendors:
   name: Test Vendor
   certificates:
     - name: Test Cert
-      url: https://example.com/test cert.cer
+      uri: https://example.com/test cert.cer
       validation:
         fingerprint:
           sha1: aa:bb:cc:dd
@@ -290,7 +290,7 @@ vendors:
   certificates:
     - name: Test Cert
       description: Test certificate description
-      url: https://example.com/test.cer
+      uri: https://example.com/test.cer
       validation:
         fingerprint:
           sha1: aa:bb:cc:dd
@@ -373,7 +373,7 @@ vendors:
       name: "Test Vendor"
       certificates:
         - name: "Test Cert"
-          url: "https://example.com/test.cer"
+          uri: "https://example.com/test.cer"
           validation:
             fingerprint:
                 sha1: "AA:BB:CC:DD"
@@ -388,7 +388,7 @@ vendors:
       name: "Test Vendor"
       certificates:
         - name: "Test Cert"
-          url: "https://example.com/test.cer"
+          uri: "https://example.com/test.cer"
           validation:
             fingerprint:
                 sha1: "AA:BB:CC:DD"
@@ -404,7 +404,7 @@ vendors:
     name: Test Vendor
     certificates:
       - name: Test Cert
-        url: https://example.com/test.cer
+        uri: https://example.com/test.cer
         validation:
           fingerprint:
             sha1: aa:bb:cc:dd
@@ -420,7 +420,7 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Test Cert"
-        url: "https://example.com/test.cer"
+        uri: "https://example.com/test.cer"
         validation:
           fingerprint:
             sha1: "aa:bb:cc:dd"
@@ -436,7 +436,7 @@ vendors:
     name: "Vendor B"
     certificates:
       - name: "Cert"
-        url: "https://example.com/b.cer"
+        uri: "https://example.com/b.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"
@@ -444,7 +444,7 @@ vendors:
     name: "Vendor A"
     certificates:
       - name: "Cert"
-        url: "https://example.com/a.cer"
+        uri: "https://example.com/a.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"
@@ -460,12 +460,12 @@ vendors:
     name: "Test Vendor"
     certificates:
       - name: "Z Cert"
-        url: "https://example.com/z.cer"
+        uri: "https://example.com/z.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"
       - name: "A Cert"
-        url: "https://example.com/a.cer"
+        uri: "https://example.com/a.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD"

--- a/internal/config/validate/yaml_validator_test.go
+++ b/internal/config/validate/yaml_validator_test.go
@@ -15,6 +15,7 @@ func TestYAMLValidator_ValidateFile(t *testing.T) {
 		yaml        string
 		wantErrors  int
 		errorChecks []string
+		wantError   string // if non-empty, expect ValidateFile() to return an error containing this string
 	}{
 		{
 			name: "valid file",
@@ -25,7 +26,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -40,7 +41,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -70,7 +71,7 @@ vendors:
     name: "Nuvoton Technology"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -78,7 +79,7 @@ vendors:
     name: "Intel"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -95,12 +96,12 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert Z"
-        url: "https://example.com/cert-z.cer"
+        uri: "https://example.com/cert-z.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Cert A"
-        url: "https://example.com/cert-a.cer"
+        uri: "https://example.com/cert-a.cer"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"
@@ -117,13 +118,13 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert with space.cer"
+        uri: "https://example.com/cert with space.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
 `,
 			wantErrors:  1,
-			errorChecks: []string{"url not properly encoded"},
+			errorChecks: []string{"uri not properly encoded"},
 		},
 		{
 			name: "http URL",
@@ -134,13 +135,12 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "http://example.com/cert.cer"
+        uri: "http://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
 `,
-			wantErrors:  1,
-			errorChecks: []string{"url must use HTTPS scheme"},
+			wantError: "invalid uri scheme 'http'",
 		},
 		{
 			name: "lowercase fingerprint",
@@ -151,7 +151,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
@@ -168,7 +168,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -185,7 +185,7 @@ vendors:
     name: "Unknown Vendor"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -202,7 +202,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert-a.cer"
+        uri: "https://example.com/cert-a.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -210,7 +210,7 @@ vendors:
     name: "STMicroelectronics Duplicate"
     certificates:
       - name: "Cert B"
-        url: "https://example.com/cert-b.cer"
+        uri: "https://example.com/cert-b.cer"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"
@@ -227,12 +227,12 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert-a.cer"
+        uri: "https://example.com/cert-a.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Cert A"
-        url: "https://example.com/cert-b.cer"
+        uri: "https://example.com/cert-b.cer"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"
@@ -249,12 +249,12 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Cert B"
-        url: "https://example.com/cert.cer"
+        uri: "https://example.com/cert.cer"
         validation:
           fingerprint:
             sha1: "11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44"
@@ -271,12 +271,12 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Cert A"
-        url: "https://example.com/cert-a.cer"
+        uri: "https://example.com/cert-a.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
       - name: "Cert B"
-        url: "https://example.com/cert-b.cer"
+        uri: "https://example.com/cert-b.cer"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -361,13 +361,13 @@ vendors:
     certificates:
       - name: "AMDTPM ECC"
         description: "test certificate"
-        url: "https://example.com/cert with space.der"
+        uri: "https://example.com/cert with space.der"
         validation:
           fingerprint:
             sha256: "C2:CB:57:BF:72:3C:17:4F:16:6C:5A:A1:DC:64:16:09:81:05:4B:EE:18:C7:0E:B1:DE:BF:C1:51:8A:FA:92:D2"
 `,
 			wantErrors:  1,
-			errorChecks: []string{"url not properly encoded"},
+			errorChecks: []string{"uri not properly encoded"},
 		},
 		{
 			name: "multiple unencoded URIs report correct line numbers",
@@ -405,6 +405,16 @@ vendors:
 
 			validator := validate.NewYAMLValidator()
 			errors, err := validator.ValidateFile(testFile)
+
+			if tt.wantError != "" {
+				if err == nil {
+					t.Fatalf("ValidateFile() expected error containing %q, but got nil", tt.wantError)
+				}
+				if !contains(err.Error(), tt.wantError) {
+					t.Fatalf("ValidateFile() error = %q, want error containing %q", err.Error(), tt.wantError)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("ValidateFile() unexpected error: %v", err)
 			}

--- a/internal/observability/init_test.go
+++ b/internal/observability/init_test.go
@@ -1,7 +1,6 @@
 package observability
 
 import (
-	"context"
 	"sync"
 	"testing"
 
@@ -9,7 +8,7 @@ import (
 )
 
 func TestInitialize_WithDisabled(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test with Enabled=false (default)
 	cfg := Config{
@@ -35,7 +34,7 @@ func TestInitialize_WithInvalidConfig(t *testing.T) {
 	// Reset state for this test
 	resetInitState()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Invalid sampler
 	cfg := Config{
@@ -83,7 +82,7 @@ func TestTracer(t *testing.T) {
 	}
 
 	// Should be able to start a span
-	ctx := context.Background()
+	ctx := t.Context()
 	_, span := tracer.Start(ctx, "test-span")
 	if span == nil {
 		t.Fatal("span should not be nil")
@@ -95,7 +94,7 @@ func TestNoopMode_TracerReturnsNoopSpan(t *testing.T) {
 	cleanup := setTracerProviderForTest()
 	defer cleanup()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Get tracer and verify it returns noop spans
 	tracer := Tracer()
@@ -153,7 +152,7 @@ func TestInitialize_ConcurrentCalls(t *testing.T) {
 	// Reset state for this test
 	resetInitState()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := Config{
 		Enabled: false,
 	}
@@ -202,7 +201,7 @@ func TestTracer_ConcurrentAccess(t *testing.T) {
 	cleanup := setTracerProviderForTest()
 	defer cleanup()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Call Tracer concurrently from multiple goroutines
 	const numGoroutines = 50
@@ -235,7 +234,7 @@ func TestNoopMode_StartSpanReturnsNoopSpan(t *testing.T) {
 	cleanup := setTracerProviderForTest()
 	defer cleanup()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Use StartSpan helper
 	_, span := StartSpan(ctx, "test-operation")
@@ -272,7 +271,7 @@ func TestTracerProvider_InitialState(t *testing.T) {
 		t.Fatal("Tracer() should not return nil")
 	}
 
-	_, span := tracer.Start(context.Background(), "test-span")
+	_, span := tracer.Start(t.Context(), "test-span")
 
 	// Should be a noop span
 	if span.IsRecording() {

--- a/pkg/apiv1beta/trusted_bundle_test.go
+++ b/pkg/apiv1beta/trusted_bundle_test.go
@@ -2,7 +2,6 @@ package apiv1beta
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -56,7 +55,7 @@ func TestPersist(t *testing.T) {
 		tb.(*trustedBundle).vendorFilter = []VendorID{IFX}
 
 		// Persist the bundle
-		if err := tb.Persist(context.Background(), tmpDir); err != nil {
+		if err := tb.Persist(t.Context(), tmpDir); err != nil {
 			t.Fatalf("Failed to persist bundle: %v", err)
 		}
 
@@ -116,7 +115,7 @@ func TestPersist(t *testing.T) {
 			t.Fatalf("Failed to create trusted bundle: %v", err)
 		}
 
-		if err := tb.Persist(context.Background(), tmpDir); err != nil {
+		if err := tb.Persist(t.Context(), tmpDir); err != nil {
 			t.Fatalf("Failed to persist bundle: %v", err)
 		}
 

--- a/tests/integration/cli/bundle/generate_test.go
+++ b/tests/integration/cli/bundle/generate_test.go
@@ -1,7 +1,6 @@
 package bundle_test
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -89,7 +88,7 @@ func TestGenerateCommand(t *testing.T) {
 				Type:       tt.typeFlag,
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if err := generate.Run(ctx, opts); err != nil {
 				t.Fatalf("generate command failed: %v", err)
 			}
@@ -149,7 +148,7 @@ func TestGenerateCommand_InvalidType(t *testing.T) {
 	}
 
 	// Run generate (should fail)
-	ctx := context.Background()
+	ctx := t.Context()
 	err = generate.Run(ctx, opts)
 	if err == nil {
 		t.Fatal("expected error for invalid bundle type, but got nil")

--- a/tests/integration/cli/config/add_test.go
+++ b/tests/integration/cli/config/add_test.go
@@ -29,7 +29,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Existing Cert"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -73,7 +73,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "GlobalSign Trusted Computing CA"
-        url: "https://secure.globalsign.com/cacert/gstpmroot.crt"
+        uri: "https://secure.globalsign.com/cacert/gstpmroot.crt"
         validation:
           fingerprint:
             sha1: "3D:5E:6B:4A:8C:2F:1E:4B:9A:7C:8D:2E:3F:4A:5B:6C:7D:8E:9F:0A"
@@ -120,7 +120,7 @@ vendors:
     certificates:
       - name: "Existing Cert"
         description: "Existing certificate description"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -155,7 +155,7 @@ vendors:
     name: "STMicroelectronics"
     certificates:
       - name: "Test Cert"
-        url: "https://example.com/cert.crt"
+        uri: "https://example.com/cert.crt"
         validation:
           fingerprint:
             sha1: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"


### PR DESCRIPTION
Notes:
 * use t.Context() everywhere
 * migrate to uri everywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and configuration examples across certificate listing, removal, validation, and formatting tests to use `uri` field for certificate locations.
  * Updated test context usage to leverage test-provided context instead of background context across multiple test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loicsikidi/tpm-ca-certificates/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->