### PR TITLE
fix(git): support tags stored in packed-refs #171

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -118,33 +118,70 @@ func findGitDir(dir string) (*os.Root, error) {
 }
 
 // findTagForCommit searches for a tag pointing to the given commit hash.
-// It reads all files in .git/refs/tags/ and returns the first tag that points to the commit.
+// It first reads individual files in .git/refs/tags/, then falls back to .git/packed-refs.
 // Returns empty string if no tag is found.
 func findTagForCommit(gitRoot *os.Root, commitHash string) (string, error) {
+	// First, try loose refs in .git/refs/tags/
 	tagsPath := filepath.Join("refs", "tags")
-
-	if _, err := gitRoot.Stat(tagsPath); os.IsNotExist(err) {
-		return "", nil
-	}
-
-	entries, err := fs.ReadDir(gitRoot.FS(), tagsPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read tags directory: %w", err)
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-
-		tagFilePath := filepath.Join(tagsPath, entry.Name())
-		tagCommit, err := fs.ReadFile(gitRoot.FS(), tagFilePath)
+	if _, err := gitRoot.Stat(tagsPath); err == nil {
+		entries, err := fs.ReadDir(gitRoot.FS(), tagsPath)
 		if err != nil {
+			return "", fmt.Errorf("failed to read tags directory: %w", err)
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			tagFilePath := filepath.Join(tagsPath, entry.Name())
+			tagCommit, err := fs.ReadFile(gitRoot.FS(), tagFilePath)
+			if err != nil {
+				continue
+			}
+
+			if strings.TrimSpace(string(tagCommit)) == commitHash {
+				return entry.Name(), nil
+			}
+		}
+	}
+
+	// Fall back to packed-refs
+	return findTagInPackedRefs(gitRoot, commitHash)
+}
+
+// findTagInPackedRefs searches for a tag in the .git/packed-refs file.
+// Returns empty string if no tag is found.
+func findTagInPackedRefs(gitRoot *os.Root, commitHash string) (string, error) {
+	packedRefsContent, err := fs.ReadFile(gitRoot.FS(), "packed-refs")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read packed-refs: %w", err)
+	}
+
+	// Parse packed-refs file
+	// Format: <commit-hash> refs/tags/<tag-name>
+	lines := strings.SplitSeq(string(packedRefsContent), "\n")
+	for line := range lines {
+		line = strings.TrimSpace(line)
+		// Skip comments and empty lines
+		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		if strings.TrimSpace(string(tagCommit)) == commitHash {
-			return entry.Name(), nil
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+
+		hash := parts[0]
+		ref := parts[1]
+
+		// Check if this is a tag ref and matches our commit
+		if strings.HasPrefix(ref, "refs/tags/") && hash == commitHash {
+			return strings.TrimPrefix(ref, "refs/tags/"), nil
 		}
 	}
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -182,6 +182,89 @@ func TestGetInfo(t *testing.T) {
 			},
 		},
 		{
+			name: "repository with tag in packed-refs",
+			setupRepo: func(t *testing.T, repoDir string) {
+				gitDir := filepath.Join(repoDir, ".git")
+				if err := os.MkdirAll(gitDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+
+				commitHash := "1234567890abcdef1234567890abcdef12345678"
+
+				// Create detached HEAD
+				if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte(commitHash+"\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+
+				// Create empty refs/tags directory
+				refsTags := filepath.Join(gitDir, "refs", "tags")
+				if err := os.MkdirAll(refsTags, 0755); err != nil {
+					t.Fatal(err)
+				}
+
+				// Create packed-refs with tag
+				packedRefs := `# pack-refs with: peeled fully-peeled sorted
+fedcba9876543210fedcba9876543210fedcba98 refs/heads/main
+1234567890abcdef1234567890abcdef12345678 refs/tags/2026-05-18
+0000000000000000000000000000000000000000 refs/tags/v1.0.0
+`
+				if err := os.WriteFile(filepath.Join(gitDir, "packed-refs"), []byte(packedRefs), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expectError: false,
+			validateResult: func(t *testing.T, info *Info) {
+				expectedCommit := "1234567890abcdef1234567890abcdef12345678"
+				if info.Commit != expectedCommit {
+					t.Errorf("expected commit %s, got %s", expectedCommit, info.Commit)
+				}
+				if info.Tag != "2026-05-18" {
+					t.Errorf("expected tag '2026-05-18', got '%s'", info.Tag)
+				}
+			},
+		},
+		{
+			name: "repository with tag in both loose refs and packed-refs",
+			setupRepo: func(t *testing.T, repoDir string) {
+				gitDir := filepath.Join(repoDir, ".git")
+				if err := os.MkdirAll(gitDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+
+				commitHash := "aaabbbcccdddeeefff000111222333444555666"
+
+				// Create detached HEAD
+				if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte(commitHash+"\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+
+				// Create tag in loose refs
+				refsTags := filepath.Join(gitDir, "refs", "tags")
+				if err := os.MkdirAll(refsTags, 0755); err != nil {
+					t.Fatal(err)
+				}
+
+				if err := os.WriteFile(filepath.Join(refsTags, "2026-01-01"), []byte(commitHash+"\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+
+				// Create packed-refs with different tag for same commit
+				packedRefs := `# pack-refs with: peeled fully-peeled sorted
+aaabbbcccdddeeefff000111222333444555666 refs/tags/2026-02-02
+`
+				if err := os.WriteFile(filepath.Join(gitDir, "packed-refs"), []byte(packedRefs), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expectError: false,
+			validateResult: func(t *testing.T, info *Info) {
+				// Should prefer loose refs over packed-refs
+				if info.Tag != "2026-01-01" {
+					t.Errorf("expected tag '2026-01-01' from loose refs, got '%s'", info.Tag)
+				}
+			},
+		},
+		{
 			name: "not a git repository",
 			setupRepo: func(t *testing.T, repoDir string) {
 				// Don't create .git directory


### PR DESCRIPTION
fixes #171 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved git tag resolution with enhanced discovery capabilities to reliably find tags across different repository storage configurations, ensuring consistent tag identification.

* **Tests**
  * Added test coverage for tag resolution in various repository states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loicsikidi/tpm-ca-certificates/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->